### PR TITLE
Update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,10 @@ Built on top of `PackageCompiler.jl`.
 - A working C compiler (`clang`/`gcc` on macOS/Linux; MSYS2 mingw on Windows)
 
 ### Installation
+Install JuliaC as a [Julia app](https://pkgdocs.julialang.org/v1/apps/):
 
 ```julia
-pkg> add JuliaC
+pkg> app add JuliaC
 ```
 
 Optional: enable `Pkg` app shims on your shell PATH so you can run `juliac` directly:
@@ -28,7 +29,8 @@ echo 'export PATH="$HOME/.julia/bin:$PATH"' >> ~/.bashrc    # adapt for your she
 
 ### Quick start (CLI)
 
-Compile an executable and produce a self-contained bundle in `build/`:
+Given an app in `test/AppProject` (see the files in this repository),
+compile an executable and produce a self-contained bundle in `build/`:
 
 ```bash
 juliac \


### PR DESCRIPTION
* Mention this should be added as an app. The link I've added is currently not working because v1.12 is not yet v1, but it will work when Julia 1.12 lands.
* Make it clearer that the quickstart CLI requires you to be in the `JuliaC` directory because it refers to local files