### PR TITLE
Add workaround for `Colon()` printing

### DIFF
--- a/src/scripts/juliac-trim-base.jl
+++ b/src/scripts/juliac-trim-base.jl
@@ -9,6 +9,7 @@ end
 (f::Base.RedirectStdStream)(io::Core.CoreSTDOUT) = Base._redirect_io_global(io, f.unix_fd)
 
 @eval Base begin
+    show(io::IO, ::Colon) = print(io, "Colon()")
     depwarn(msg, funcsym; force::Bool=false) = nothing
     _assert_tostring(msg) = ""
     reinit_stdio() = nothing

--- a/test/lib_project/src/libtest.jl
+++ b/test/lib_project/src/libtest.jl
@@ -1,7 +1,10 @@
 module LibTest
 
 Base.@ccallable function jc_add_one(x::Cint)::Cint
-    return x + 1
+    # this convoluted logic is to check that we support reshape with `Colon()`,
+    # which tries to `show(::IO, ::Colon)` internally and used to fail
+    m = reshape([x,x,x,x], :, 2)
+    return m[1,1] + 1
 end
 
 end # module


### PR DESCRIPTION
The printing for this in Base uses fallback pathways w/ heavy dynamic dispatch.

That should probably be cleaned up, but for now this resolves this particular case with a simple override.