### PR TITLE
Use the same default CPU target as PackageCompiler

### DIFF
--- a/src/compiling.jl
+++ b/src/compiling.jl
@@ -66,14 +66,11 @@ function compile_products(recipe::ImageRecipe)
         get!(recipe.jl_options, "threads", "1")
     end
     if recipe.cpu_target === nothing
-        recipe.cpu_target = get(ENV,"JULIA_CPU_TARGET", nothing)
+        default_cpu_target = PackageCompiler.default_app_cpu_target()
+        recipe.cpu_target = get(ENV, "JULIA_CPU_TARGET", default_cpu_target)
     end
     julia_cmd = `$(Base.julia_cmd(;cpu_target=recipe.cpu_target)) --startup-file=no --history-file=no`
-    if recipe.cpu_target !== nothing
-        precompile_cpu_target = String(first(split(recipe.cpu_target, [';',','])))
-    else
-        precompile_cpu_target = nothing
-    end
+    precompile_cpu_target = String(first(split(recipe.cpu_target, [';',','])))
     # Ensure the app project is instantiated and precompiled
     if isdir(recipe.file)
         if recipe.project != ""

--- a/test/trimming.jl
+++ b/test/trimming.jl
@@ -24,8 +24,8 @@ const TRIM_PROJ = abspath(joinpath(@__DIR__, "TrimmabilityProject"))
     actual_exe = Sys.iswindows() ? joinpath(outdir, "bin", basename(exeout) * ".exe") : joinpath(outdir, "bin", basename(exeout))
     @test isfile(actual_exe)
 
-    # Test that the executable size stays reasonable (< 2.5MB for the executable itself)
-    @test filesize(actual_exe) < 2_500_000
+    # Test that the executable size stays reasonable (< 3.5MB for the executable itself)
+    @test filesize(actual_exe) < 3_500_000
 
     print_tree_with_sizes(outdir)
 end


### PR DESCRIPTION
Fix https://github.com/JuliaLang/JuliaC.jl/issues/33.

~~I was hoping it was just a matter of changing the defaults, but it seems to cause segfaults for me running testset "Programmatic binary (trim)" locally on Windows.~~

EDIT: indeed fixed by https://github.com/JuliaLang/julia/issues/58952#issuecomment-3076371765, so requires 1.12.3