### PR TITLE
reset load path to fix usage as an app

### DIFF
--- a/src/compiling.jl
+++ b/src/compiling.jl
@@ -78,7 +78,8 @@ function compile_products(recipe::ImageRecipe)
     end
 
     project_arg = recipe.project == "" ? Base.active_project() : recipe.project
-    inst_cmd = `$(Base.julia_cmd(cpu_target=precompile_cpu_target)) --project=$project_arg -e "using Pkg; Pkg.instantiate(); Pkg.precompile()"`
+    env_overrides = Dict{String,Any}("JULIA_LOAD_PATH"=>nothing)
+    inst_cmd = addenv(`$(Base.julia_cmd(cpu_target=precompile_cpu_target)) --project=$project_arg -e "using Pkg; Pkg.instantiate(); Pkg.precompile()"`, env_overrides...)
     recipe.verbose && println("Running: $inst_cmd")
     precompile_time = time_ns()
     if !success(pipeline(inst_cmd; stdout, stderr))
@@ -109,6 +110,7 @@ function compile_products(recipe::ImageRecipe)
     end
 
     # Threading
+    cmd = addenv(cmd, env_overrides...)
     recipe.verbose && println("Running: $cmd")
     # Show a spinner while the compiler runs
     spinner_done, spinner_task = _start_spinner("Compiling...")


### PR DESCRIPTION
The pkg app mechanism sets JULIA_LOAD_PATH so we must unset it here or else nothing works.

We have a more general problem that JuliaC and the user's code might be in different depots, so one environment variable is not sufficient. I don't think we can support specifying it by env var; you will have to pass a `--depot-path` arg to juliac to use a different depot.

For now this change should be ok; I don't think setting LOAD_PATH is as common or useful as DEPOT_PATH? To support it we'd also have to add a command line arg, or else the app loading mechanism has to be changed somehow.