### PR TITLE
Revise CI workflow for Julia version and platforms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,16 +14,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [ 'pre' ]
-        os: [ ubuntu-latest, windows-latest, macos-14]
-        arch: [ x64, arm64 ]
-        exclude:
-          - os: windows-latest
-            arch: arm64
-          - os: ubuntu-latest
-            arch: arm64
+        version: [ '1' ]
+        os: [ ubuntu-latest, windows-latest, macos-15-intel]
+        arch: [ x64 ]
+        include:
+          - os: macos-latest
+            arch: aarch64
+            version: '1'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}


### PR DESCRIPTION
Updated CI workflow to use Julia version '1' and modified OS and architecture configurations.

`pre` should be added back to CI when we have pre-releases for the next Julia release.