### PR TITLE
Add PATH for fish shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,13 @@ pkg> app add JuliaC
 
 Optional: enable `Pkg` app shims on your shell PATH so you can run `juliac` directly:
 
+Bash:
 ```bash
-echo 'export PATH="$HOME/.julia/bin:$PATH"' >> ~/.bashrc    # adapt for your shell
+echo 'export PATH="$HOME/.julia/bin:$PATH"' >> ~/.bashrc 
+```
+Fish:
+```fish
+echo 'fish_add_path $HOME/.julia/bin' >> ~/.config/fish/config.fish
 ```
 
 ### Quick start (CLI)


### PR DESCRIPTION
This adds an instruction on how to add Julia to the path for the fish shell. 
Also arranges the bash instruction and prepares for other shell instructions. 

Here is how it renders: 

<img width="2408" height="507" alt="Screenshot_20251027_021259" src="https://github.com/user-attachments/assets/c3fbda5a-6868-4637-9322-836a770ab960" />
