### PR TITLE
Only link and bundle in command line script when not building with `--output-o` or `--output-bc`

### DIFF
--- a/src/JuliaC.jl
+++ b/src/JuliaC.jl
@@ -173,7 +173,10 @@ function _main_cli(args::Vector{String}; io::IO=stdout)
         # Only link when not building with --output-o or --output-bc
         link_products(link)
     end
-    bundle_products(bun)
+    if should_be_bundled(bun)
+        # Only bundle when not building with --output-o or --output-bc
+        bundle_products(bun)
+    end
 end
 
 function (@main)(ARGS)

--- a/src/JuliaC.jl
+++ b/src/JuliaC.jl
@@ -169,7 +169,10 @@ function _main_cli(args::Vector{String}; io::IO=stdout)
     end
     img, link, bun = _parse_cli_args(args)
     compile_products(img)
-    link_products(link)
+    if should_be_linked(link)
+        # Only link when not building with --output-o or --output-bc
+        link_products(link)
+    end
     bundle_products(bun)
 end
 

--- a/src/bundling.jl
+++ b/src/bundling.jl
@@ -1,9 +1,14 @@
+function should_be_bundled(recipe::BundleRecipe)
+    output_type = recipe.link_recipe.image_recipe.output_type
+    return !(output_type == "--output-o" || output_type == "--output-bc")
+end
+
 function bundle_products(recipe::BundleRecipe)
     bundle_start = time_ns()
 
     # Validate that bundling makes sense for this output type
-    output_type = recipe.link_recipe.image_recipe.output_type
-    if output_type == "--output-o" || output_type == "--output-bc"
+    if !should_be_bundled(recipe)
+        output_type = recipe.link_recipe.image_recipe.output_type
         error("Cannot bundle $(output_type) output type. $(output_type) generates object files/archives that don't require bundling. Use compile_products() directly instead of bundle_products().")
     end
 

--- a/src/linking.jl
+++ b/src/linking.jl
@@ -63,12 +63,16 @@ function get_compiler_cmd(; cplusplus::Bool=false)
     return compiler_cmd
 end
 
+function should_be_linked(recipe::LinkRecipe)
+    return !(recipe.image_recipe.output_type == "--output-o" || recipe.image_recipe.output_type == "--output-bc")
+end
+
 function link_products(recipe::LinkRecipe)
     link_start = time_ns()
     image_recipe = recipe.image_recipe
 
     # Validate that linking makes sense for this output type
-    if image_recipe.output_type == "--output-o" || image_recipe.output_type == "--output-bc"
+    if !should_be_linked(recipe)
         error("Cannot link $(image_recipe.output_type) output type. $(image_recipe.output_type) generates object files/archives that don't require linking. Use compile_products() directly instead of link_products().")
     end
     if image_recipe.output_type == "--output-lib" || image_recipe.output_type == "--output-sysimage"


### PR DESCRIPTION
Currently the commandline script _always_ throws errors when using the `--output-o` and `--output-bc` flags as `link_products` and `bundle_products` is always called regardless of flags set.
I have added in this PR guards which only call these when we should. 