### PR TITLE
Fixup rpath usage when not bundling.

### DIFF
--- a/src/linking.jl
+++ b/src/linking.jl
@@ -1,6 +1,14 @@
+# Magic rpath strings:
+#   @julia  - Use absolute paths to the Julia installation's libraries (for non-bundled builds)
+#   @bundle - Use relative rpaths for standard bundle layout (../lib on Unix, bin on Windows)
+const RPATH_JULIA = "@julia"
+const RPATH_BUNDLE = "@bundle"
+
 function get_rpath(recipe::LinkRecipe)
-    if recipe.rpath === nothing
-        # No bundling - use absolute paths to Julia installation's libraries
+    rpath = recipe.rpath
+
+    # Handle @julia magic string - absolute paths to Julia installation
+    if rpath == RPATH_JULIA
         if Sys.iswindows()
             return ""
         end
@@ -8,7 +16,15 @@ function get_rpath(recipe::LinkRecipe)
         private_libdir = JuliaConfig.private_libDir()
         return "-Wl,-rpath,'$(libdir)' -Wl,-rpath,'$(private_libdir)'"
     end
-    # Bundling case - use relative rpaths
+
+    # Handle @bundle magic string - standard bundle layout
+    if rpath == RPATH_BUNDLE
+        if Sys.iswindows()
+            rpath = ""
+        else
+            rpath = joinpath("..", "lib")
+        end
+    end
     if Sys.isapple()
         base_token = "-Wl,-rpath,'@loader_path/"
     elseif Sys.islinux()
@@ -17,9 +33,9 @@ function get_rpath(recipe::LinkRecipe)
         @warn "get_rpath not implemented for this platform"
         return ""
     end
-    # If rpath is a relative subdir (e.g., "lib"), emit @loader_path/lib and @loader_path/lib/julia
-    priv_path = joinpath(recipe.rpath, "julia")
-    base_path = recipe.rpath
+    # Emit rpaths for both base path and julia subdirectory
+    priv_path = joinpath(rpath, "julia")
+    base_path = rpath
     flag1 = base_token * base_path * "'"
     flag2 = base_token * priv_path * "'"
     return string(flag1, " ", flag2)

--- a/test/cli.jl
+++ b/test/cli.jl
@@ -158,11 +158,7 @@ end
     @test img.trim_mode == "safe"
     @test link.outname == "app"
     @test bun.output_dir == abspath(dirname(link.outname))
-    if Sys.iswindows()
-        @test link.rpath == bun.libdir
-    else
-        @test link.rpath == joinpath("..", bun.libdir)
-    end
+    @test link.rpath == JuliaC.RPATH_BUNDLE  # Should use @bundle when bundling
 
     # Library with explicit bundle dir, ccallable and experimental
     outdir = mktempdir()
@@ -183,13 +179,8 @@ end
     @test img2.trim_mode == "safe"
     @test link2.outname == joinpath(outdir, "mylib")
     @test bun2.output_dir == outdir
-    if Sys.iswindows()
-        @test link2.rpath == bun2.libdir
-    else
-        @test link2.rpath == joinpath("..", bun2.libdir)
-    end
+    @test link2.rpath == JuliaC.RPATH_BUNDLE  # Should use @bundle when bundling
 
-    # Without --bundle, rpath should be nothing (uses system Julia rpaths)
     args3 = String[
         "--output-exe", "app",
         "--project", TEST_PROJ,
@@ -199,7 +190,7 @@ end
     ]
     img3, link3, bun3 = JuliaC._parse_cli_args(args3)
     @test img3.output_type == "--output-exe"
-    @test link3.rpath === nothing  # Should be nothing when not bundling
+    @test link3.rpath == JuliaC.RPATH_JULIA  # Should use @julia when not bundling
     @test bun3.output_dir === nothing  # No bundling
 
     # Errors: unknown option

--- a/test/programatic.jl
+++ b/test/programatic.jl
@@ -14,9 +14,7 @@
     @testset "Programmatic API (trim)" begin
         outdir = mktempdir()
         outname = joinpath(outdir, "lib")
-        # When bundling, set rpath to point to bundle's lib directory
-        bundle_rpath = Sys.iswindows() ? "bin" : joinpath("..", "lib")
-        link = JuliaC.LinkRecipe(image_recipe=img_lib, outname=outname, rpath=bundle_rpath)
+        link = JuliaC.LinkRecipe(image_recipe=img_lib, outname=outname, rpath=JuliaC.RPATH_BUNDLE)
         JuliaC.link_products(link)
         @test isfile(startswith(outname, "/") ? outname * "." * Base.BinaryPlatforms.platform_dlext() : joinpath(dirname(outname), basename(outname) * "." * Base.BinaryPlatforms.platform_dlext())) || isfile(outname)
 
@@ -48,9 +46,7 @@
         if Sys.isunix()
             outdir = mktempdir()
             libout = joinpath(outdir, "libprivtest")
-            # When bundling, set rpath to point to bundle's lib directory
-            bundle_rpath = joinpath("..", "lib")
-            link = JuliaC.LinkRecipe(image_recipe=img_lib, outname=libout, rpath=bundle_rpath)
+            link = JuliaC.LinkRecipe(image_recipe=img_lib, outname=libout, rpath=JuliaC.RPATH_BUNDLE)
             JuliaC.link_products(link)
             bun = JuliaC.BundleRecipe(link_recipe=link, output_dir=outdir, privatize=true)
             JuliaC.bundle_products(bun)
@@ -79,9 +75,7 @@
         if Sys.isunix()
             outdir = mktempdir()
             libout = joinpath(outdir, "libctest")
-            # When bundling, set rpath to point to bundle's lib directory
-            bundle_rpath = joinpath("..", "lib")
-            link = JuliaC.LinkRecipe(image_recipe=img_lib, outname=libout, rpath=bundle_rpath)
+            link = JuliaC.LinkRecipe(image_recipe=img_lib, outname=libout, rpath=JuliaC.RPATH_BUNDLE)
             JuliaC.link_products(link)
             bun = JuliaC.BundleRecipe(link_recipe=link, output_dir=outdir)
             JuliaC.bundle_products(bun)
@@ -105,9 +99,7 @@
         if Sys.isunix()
             outdir = mktempdir()
             libout = joinpath(outdir, "libjldlopentest")
-            # When bundling, set rpath to point to bundle's lib directory
-            bundle_rpath = joinpath("..", "lib")
-            link = JuliaC.LinkRecipe(image_recipe=img_lib, outname=libout, rpath=bundle_rpath)
+            link = JuliaC.LinkRecipe(image_recipe=img_lib, outname=libout, rpath=JuliaC.RPATH_BUNDLE)
             JuliaC.link_products(link)
             bun = JuliaC.BundleRecipe(link_recipe=link, output_dir=outdir, privatize=true)
             JuliaC.bundle_products(bun)
@@ -129,9 +121,7 @@
             outdir = mktempdir()
             libname = "libhassonametest"
             libout = joinpath(outdir, libname)
-            # When bundling, set rpath to point to bundle's lib directory
-            bundle_rpath = joinpath("..", "lib")
-            link = JuliaC.LinkRecipe(image_recipe=img_lib, outname=libout, rpath=bundle_rpath)
+            link = JuliaC.LinkRecipe(image_recipe=img_lib, outname=libout, rpath=JuliaC.RPATH_BUNDLE)
             JuliaC.link_products(link)
             bun = JuliaC.BundleRecipe(link_recipe=link, output_dir=outdir)
             JuliaC.bundle_products(bun)
@@ -149,9 +139,7 @@
             outdir = mktempdir()
             libname = "libhasinstallnametest"
             libout = joinpath(outdir, libname)
-            # When bundling, set rpath to point to bundle's lib directory
-            bundle_rpath = joinpath("..", "lib")
-            link = JuliaC.LinkRecipe(image_recipe=img_lib, outname=libout, rpath=bundle_rpath)
+            link = JuliaC.LinkRecipe(image_recipe=img_lib, outname=libout, rpath=JuliaC.RPATH_BUNDLE)
             JuliaC.link_products(link)
             bun = JuliaC.BundleRecipe(link_recipe=link, output_dir=outdir)
             JuliaC.bundle_products(bun)
@@ -170,9 +158,7 @@
             outdir = mktempdir()
             libname = "libhasimplibtest"
             libout = joinpath(outdir, libname)
-            # When bundling, set rpath to point to bundle's lib directory
-            bundle_rpath = "bin"
-            link = JuliaC.LinkRecipe(image_recipe=img_lib, outname=libout, rpath=bundle_rpath)
+            link = JuliaC.LinkRecipe(image_recipe=img_lib, outname=libout, rpath=JuliaC.RPATH_BUNDLE)
             JuliaC.link_products(link)
             bun = JuliaC.BundleRecipe(link_recipe=link, output_dir=outdir)
             JuliaC.bundle_products(bun)
@@ -195,9 +181,7 @@ end
         verbose = true,
     )
     JuliaC.compile_products(img)
-    # When bundling, set rpath to point to bundle's lib directory
-    bundle_rpath = Sys.iswindows() ? "bin" : joinpath("..", "lib")
-    link = JuliaC.LinkRecipe(image_recipe=img, outname=exeout, rpath=bundle_rpath)
+    link = JuliaC.LinkRecipe(image_recipe=img, outname=exeout, rpath=JuliaC.RPATH_BUNDLE)
     JuliaC.link_products(link)
     bun = JuliaC.BundleRecipe(link_recipe=link, output_dir=outdir)
     JuliaC.bundle_products(bun)
@@ -307,9 +291,7 @@ end
         verbose = true,
     )
     JuliaC.compile_products(img)
-    # When bundling, set rpath to point to bundle's lib directory
-    bundle_rpath = Sys.iswindows() ? "bin" : joinpath("..", "lib")
-    link = JuliaC.LinkRecipe(image_recipe=img, outname=exeout, rpath=bundle_rpath)
+    link = JuliaC.LinkRecipe(image_recipe=img, outname=exeout, rpath=JuliaC.RPATH_BUNDLE)
     JuliaC.link_products(link)
     bun = JuliaC.BundleRecipe(link_recipe=link, output_dir=outdir)
     JuliaC.bundle_products(bun)


### PR DESCRIPTION
This fixes the usage of juliac when not using --bundle. This doesn't work on windows because of how linking works there but should make mac/linux not require bundling for usage

Fixes https://github.com/JuliaLang/JuliaC.jl/issues/46
