### PR TITLE
Bundle certificate

### DIFF
--- a/src/bundling.jl
+++ b/src/bundling.jl
@@ -20,6 +20,7 @@ function bundle_products(recipe::BundleRecipe)
                           intersect(PackageCompiler._STDLIBS, map(x->x.name, Base._sysimage_modules))))
     PackageCompiler.bundle_julia_libraries(recipe.output_dir, stdlibs)
     PackageCompiler.bundle_artifacts(ctx2, recipe.output_dir; include_lazy_artifacts=false) # Lazy artifacts
+    PackageCompiler.bundle_cert(recipe.output_dir) # SSL certificates
 
     # Re-home bundled libraries into the desired bundle layout
     libdir = recipe.libdir


### PR DESCRIPTION
error when compiling any package that has MbedTLS.jl as a dependency:

```
fatal: error thrown and no exception handler available.
Core.InitError(mod=:MbedTLS, error=Base.SystemError(prefix="opening file \"C:\\\\Example.jl\\\\compile\\\\build\\\\share\\\\julia\\\\cert.pem\"", errnum=Int32(2), extrainfo=nothing))
#systemerror#36 at .\error.jl:186
systemerror at .\error.jl:186
systemerror at .\error.jl:186
#open#637 at .\iostream.jl:317
open at .\iostream.jl:296 [inlined]
#open#330 at .\io.jl:408
open at .\io.jl:407 [inlined]
read at .\io.jl:507 [inlined]
__sslinit__ at C:\Users\rsampaio\.julia\packages\MbedTLS\Vaaz8\src\ssl.jl:819
__init__ at C:\Users\rsampaio\.julia\packages\MbedTLS\Vaaz8\src\MbedTLS.jl:55
jfptr___init___54549 at C:\Example.jl\compile\build\bin\Example.exe (unknown line)
jl_apply at C:/workdir/src\julia.h:2391 [inlined]
jl_module_run_initializer at C:/workdir/src\toplevel.c:68
_finish_jl_init_ at C:/workdir/src\init.c:625
ijl_init_ at C:/workdir/src\init.c:776
ijl_init_with_image_handle at C:/workdir/src\jlapi.c:87
ijl_autoinit_and_adopt_thread at C:/workdir/src\threading.c:466
.text at C:\Example.jl\compile\build\bin\Example.exe (unknown line)
__tmainCRTStartup at C:\Example.jl\compile\build\bin\Example.exe (unknown line)
.l_start at C:\Example.jl\compile\build\bin\Example.exe (unknown line)
BaseThreadInitThunk at C:\WINDOWS\System32\KERNEL32.DLL (unknown line)
RtlUserThreadStart at C:\WINDOWS\SYSTEM32\ntdll.dll (unknown line)
```

https://github.com/JuliaLang/PackageCompiler.jl/pull/711