### PR TITLE
Fix bundling and rpath docs for library API

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ img = ImageRecipe(
 link = LinkRecipe(
     image_recipe = img,
     outname      = "build/app_test_exe",
-    rpath        = nothing, # set automatically when bundling
+    rpath        = "@bundle", # set only when bundling
 )
 
 bun = BundleRecipe(
@@ -100,7 +100,7 @@ bundle_products(bun)
 
 ### Bundling and rpath
 
-When `--bundle` (or `BundleRecipe.output_dir`) is set, JuliaC:
+When `--bundle` (or `BundleRecipe.output_dir` and `LinkRecipe.rpath == "@bundle"`) is set, JuliaC:
 - Places the executable in `<output_dir>/bin` and libraries in `<output_dir>/lib` and `<output_dir>/lib/julia` (Windows: everything under `<output_dir>/bin`).
 - Copies required artifacts alongside the bundle.
 - Links your output with a relative rpath so the executable finds sibling libs (Unix uses `@loader_path/../lib` or `$ORIGIN/../lib`).


### PR DESCRIPTION
The rpath is only automatically set to at-bundle when using the CLI:

https://github.com/JuliaLang/JuliaC.jl/blob/ed13d9ece8db9bb29cdf5230c76a8f1de11c3ecd/src/JuliaC.jl#L173-L179

For the library API this wouldn't make sense since bundling happens after linking, so at linking time we don't know yet if the user wants to bundle.

This led to some confusion when the libraries had absolute rpaths set to the Julia installation of our build server.