### PR TITLE
Link libm on Linux if needed

### DIFF
--- a/src/linking.jl
+++ b/src/linking.jl
@@ -149,7 +149,8 @@ function link_products(recipe::LinkRecipe)
         elseif Sys.isapple()
             cmd2 = `$cmd2 -Wl,-install_name,@rpath/$(lib_name)`
         elseif Sys.islinux()
-            cmd2 = `$cmd2 -Wl,-soname,$(lib_name)`
+            # Link libm if the compiled code references math symbols, e.g. with --cpu-target=generic
+            cmd2 = `$cmd2 -Wl,-soname,$(lib_name) -Wl,--as-needed -lm`
         end
         image_recipe.verbose && println("Running: $cmd2")
         run_with_suppressed_output(cmd2; quiet=image_recipe.quiet) ||

--- a/test/MathApp/Project.toml
+++ b/test/MathApp/Project.toml
@@ -1,0 +1,3 @@
+name = "MathApp"
+uuid = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+version = "0.1.0"

--- a/test/MathApp/src/MathApp.jl
+++ b/test/MathApp/src/MathApp.jl
@@ -1,0 +1,13 @@
+module MathApp
+
+function (@main)(args)
+    # Use a transcendental math function to exercise libm linking.
+    # With --cpu-target=generic, LLVM emits calls to libm symbols (e.g. sin)
+    # that must be resolved at link time via -lm.
+    # The argument must be a runtime value to prevent LLVM from constant-folding the call.
+    x = parse(Float64, get(args, 1, "1.0"))
+    println(Core.stdout, "sin(", x, ") = ", sin(x))
+    return 0
+end
+
+end

--- a/test/cli.jl
+++ b/test/cli.jl
@@ -420,3 +420,22 @@ if Sys.isunix()
     end
 end
 end
+
+# Regression test: linking with --cpu-target=generic must succeed when
+# the compiled code references transcendental math functions (sin, cos, …)
+# that live in libm on Linux.  Without -lm in the link command this fails
+# with unresolved symbols.
+if Sys.islinux()
+    @testset "CLI app with math and --cpu-target=generic" begin
+        math_proj = abspath(joinpath(@__DIR__, "MathApp"))
+        outdir = mktempdir()
+        # Force generic CPU target to trigger libm symbol references
+        withenv("JULIA_CPU_TARGET" => "generic") do
+            run_juliac_cli(["--output-exe", "mathapp", "--trim", math_proj, "--bundle", outdir])
+        end
+        actual_exe = joinpath(outdir, "bin", "mathapp")
+        @test isfile(actual_exe)
+        output = read(`$actual_exe 1.0`, String)
+        @test occursin("sin(1.0) = ", output)
+    end
+end


### PR DESCRIPTION
`libm` seems to be needed on Linux when there is no native CPU instruction to calculate transcendent math functions. So link to it on Linux when necessary.

This is needed, when you e.g. use the equivalent of `--cpu-target=generic` and call such a math function which gets evaluated at runtime.

I had a lot of help from Opus 4.6 when creating this, but I hope I condensed it down to the essential.