### PR TITLE
Fix Permission denied when compiling from read-only Pkg dir also make sure files are writable

### DIFF
--- a/src/compiling.jl
+++ b/src/compiling.jl
@@ -94,6 +94,14 @@ function compile_products(recipe::ImageRecipe)
         dst = joinpath(tmp_project, f)
         cp(src, dst; force=true)
     end
+    # Ensure copied files are writable — Pkg-installed packages are read-only,
+    # and cp() preserves permissions. Pkg.instantiate() needs to write Manifest.toml etc.
+    for (root, dirs, files) in walkdir(tmp_project)
+        for name in Iterators.flatten((dirs, files))
+            p = joinpath(root, name)
+            chmod(p, filemode(p) | 0o200)
+        end
+    end
     project_arg = isdir(project_arg) ? tmp_project : joinpath(tmp_project, basename(project_arg))
 
     env_overrides = Dict{String,Any}()

--- a/src/privatize_common.jl
+++ b/src/privatize_common.jl
@@ -56,6 +56,7 @@ function privatize_libjulia_common!(recipe::BundleRecipe, platform::PrivatizePla
         salted_base = string(salt, "_", base)
         salted_path = joinpath(dirname(p), salted_base)
         cp(p, salted_path; force=true)
+        chmod(salted_path, filemode(salted_path) | 0o200)  # ensure writable for patching
         push!(originals_to_remove, p)
         # Update library identity for salted copy (install_name/SONAME) via unified hook
         plat_set_library_id!(platform, salted_path, plat_dep_prefix(platform) * salted_base)


### PR DESCRIPTION
## Summary
- PR #120 copied the project to a temp dir so `Pkg.instantiate()` can write `Manifest.toml`, but `cp()` preserves permissions from the source
- Since Pkg-installed packages are read-only, the copies are too, causing `SystemError: opening file ".../Project.toml": Permission denied` in CI
- Add a `walkdir`+`chmod` pass after copying to ensure all files are writable

Fixes the CI failures in https://github.com/JuliaCI/julia-buildkite/pull/536 (all 5 JuliaC test jobs failing).

## Test plan
- [x] Verify the fix addresses the `Permission denied` error on Linux (sandbox with uid remapping)
- [x] Verify the fix addresses the `ABI export` test failure on macOS (read-only `~/.julia/packages/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)