### PR TITLE
Fix-up `--trim` support for `hcat` / `vcat` / etc.

### DIFF
--- a/src/scripts/juliac-trim-base.jl
+++ b/src/scripts/juliac-trim-base.jl
@@ -121,6 +121,29 @@ end
     setfield!(typeof(Base.print).name, :max_args, Int32(10), :monotonic)
     setfield!(typeof(Base.println).name, :max_args, Int32(10), :monotonic)
     setfield!(typeof(Base.print_to_string).name, :max_args, Int32(10), :monotonic)
+
+    # not `--trim`-compatible if these resolve to a Varargs{...} specialization, primarily
+    # due to `Core._apply_iterate` having no dispatch-resolved form (#57830)
+    setfield!(typeof(_cat).name, :max_args, Int32(10), :monotonic)
+    setfield!(typeof(__cat).name, :max_args, Int32(10), :monotonic)
+    setfield!(typeof(__cat_offset!).name, :max_args, Int32(10), :monotonic)
+    setfield!(typeof(cat_size_shape).name, :max_args, Int32(10), :monotonic)
+    setfield!(typeof(_cat_size_shape).name, :max_args, Int32(10), :monotonic)
+
+    # vcat / hcat / hvcat / hvncat / cat all use this
+    unwrap_val(dims) = dims
+    unwrap_val(::Val{dims}) where dims = dims
+    function _cat_t(dims, ::Type{T}, X::Vararg{AbstractArray,N}) where {T,N}
+        @inline
+        Ndims = maximum(map(ndims, X))
+        catdims = ntuple(in(unwrap_val(dims)), Val(Ndims))
+        shape = cat_size_shape(catdims, X...)
+        A = cat_similar(X[1], T, shape)
+        if count(!iszero, catdims)::Int > 1
+            fill!(A, zero(T))
+        end
+        return __cat(A, shape, catdims, X...)
+    end
 end
 
 # Used for LinearAlgebre ldiv with SVD

--- a/test/TrimmabilityProject/src/TrimmabilityProject.jl
+++ b/test/TrimmabilityProject/src/TrimmabilityProject.jl
@@ -19,6 +19,69 @@ end
 area(s::Square) = s.side^2
 area(c::Circle) = pi*c.radius^2
 
+function _test_cat()
+    # hcat
+    _cat1a = hcat(randn(3), rand(3), randn(3))
+    _cat1b = [randn(3) rand(3) randn(3)]
+    _cat1c = hcat(randn(3,3), rand(3,3), randn(3,3))
+    _cat1d = [randn(3,3) rand(3,3) randn(3,3)]
+    _cat1e = hcat(randn(3,3,3), rand(3,3,3), randn(3,3,3))
+    _cat1f = [randn(3,3,3) rand(3,3,3) randn(3,3,3)]
+
+    # vcat
+    _cat2a = vcat(randn(3), rand(3), randn(3))
+    _cat2b = [randn(3); rand(3); randn(3)]
+    _cat2c = vcat(randn(3,3), rand(3,3), randn(3,3))
+    _cat2d = [randn(3,3); rand(3,3); randn(3,3)]
+    _cat2e = vcat(randn(3,3,3), rand(3,3,3), randn(3,3,3))
+    _cat2f = [randn(3,3,3); rand(3,3,3); randn(3,3,3)]
+
+    # hvcat
+    _cat3a = hvcat((2,2), rand(3,2), randn(3,4), rand(1,2), randn(1,4))
+    _cat3b = [rand(3,2) randn(3,4); rand(1,2) randn(1,4)]
+    _cat3c = hvcat((2, 2), rand(5,2,3), rand(5,4,3), rand(1,2,3), rand(1,4,3))
+    _cat3d = [rand(5,2,3) rand(5,4,3); rand(1,2,3) rand(1,4,3)]
+
+    # cat
+    _cat4a = cat(randn(3), randn(3); dims = 1)
+    _cat4b = cat(randn(3,3,3), randn(3,3,3); dims = 2)
+    _cat4c = cat(randn(3), randn(3,3); dims = 2)
+    _cat4d = cat(randn(3), randn(3), rand(3), rand(3), randn(3), randn(3); dims = (1,))
+    _cat4e = cat(randn(3,3), randn(3,3), rand(3,3), rand(3,3), randn(3,3), randn(3,3); dims = (1,2))
+    _cat4f = cat(randn(3,3,3), randn(3,3); dims=(1,3))
+
+    # hvncat
+    _cat5a = hvncat(2, randn(3), randn(3), randn(3))
+    _cat5b = [randn(3) ;; randn(3) ;; randn(3)]
+    _cat5c = hvncat(2, randn(3,3), randn(3,3), randn(3,3))
+    _cat5d = [randn(3,3) ;; randn(3,3) ;; randn(3,3)]
+    _cat5e = hvncat((1, 2, 2), false, randn(2,3), randn(2,3), randn(2,3), randn(2,3))
+    _cat5f = [randn(2,3) ;; randn(2,3) ;;; randn(2,3) ;; randn(2,3)]
+
+    # stack
+    _cat6a = stack([randn(3), randn(3), randn(3)])
+    _cat6b = stack([randn(3), randn(3), randn(3)]; dims=1)
+    _cat6c = stack([randn(2,3), randn(2,3)]; dims=3)
+    _cat6d = stack(x -> x .^ 2, [randn(3), randn(3)])
+
+    # repeat
+    _cat7a = repeat(randn(3), 2)
+    _cat7b = repeat(randn(2,3), 2, 3)
+    _cat7c = repeat(randn(2,3); inner=(2,1), outer=(1,3))
+    _cat7d = repeat(randn(3,3,3), 1, 2, 1)
+
+    # aggregate to prevent deletion
+    _cat1 = _cat1a[1] + _cat1b[1] + _cat1c[1] + _cat1d[1] + _cat1e[1] + _cat1f[1]
+    _cat2 = _cat2a[1] + _cat2b[1] + _cat2c[1] + _cat2d[1] + _cat2e[1] + _cat2f[1]
+    _cat3 = _cat3a[1] + _cat3b[1] + _cat3c[1] + _cat3d[1]
+    _cat4 = _cat4a[1] + _cat4b[1] + _cat4c[1] + _cat4d[1] + _cat4e[1] + _cat4f[1]
+    _cat5 = _cat5a[1] + _cat5b[1] + _cat5c[1] + _cat5d[1] + _cat5e[1] + _cat5f[1]
+    _cat6 = _cat6a[1] + _cat6b[1] + _cat6c[1] + _cat6d[1]
+    _cat7 = _cat7a[1] + _cat7b[1] + _cat7c[1] + _cat7d[1]
+
+    return _cat1 + _cat2 + _cat3 + _cat4 + _cat5 + _cat6 + _cat7
+end
+
 function @main(args::Vector{String})::Cint
     println(Core.stdout, str())
     println(Core.stdout, PROGRAM_FILE)
@@ -36,6 +99,8 @@ function @main(args::Vector{String})::Cint
     c = map(x -> x^2, sorted_arr)
     d = mapreduce(x -> x^2, +, sorted_arr)
     # e = reduce(xor, rand(Int, 10))
+
+    println(Core.stdout, _test_cat())
 
     try
         sock = connect("localhost", 4900)

--- a/test/trimming.jl
+++ b/test/trimming.jl
@@ -56,14 +56,16 @@ end
     # 3. arg1
     # 4. arg2
     # 5. The sum_areas result: 4.0 + pi = 7.141592653589793
+    # 6. _test_cat() result (a Float64)
     output = readchomp(`$actual_exe arg1 arg2`)
     lines = split(output, '\n')
-    @test length(lines) >= 5
+    @test length(lines) >= 6
     @test lines[1] == "Hello, world!"
     @test lines[2] == actual_exe  # PROGRAM_FILE
     @test lines[3] == "arg1"
     @test lines[4] == "arg2"
     @test parse(Float64, lines[5]) ≈ (4.0 + pi)
+    @test parse(Float64, lines[6]) isa Float64
 
     print_tree_with_sizes(outdir)
 end


### PR DESCRIPTION
JuliaC-equivalent to https://github.com/JuliaLang/julia/pull/61551/