### PR TITLE
Don't rely on Pkg being present in the juliac env

### DIFF
--- a/src/compiling.jl
+++ b/src/compiling.jl
@@ -104,12 +104,13 @@ function compile_products(recipe::ImageRecipe)
     end
     project_arg = isdir(project_arg) ? tmp_project : joinpath(tmp_project, basename(project_arg))
 
-    env_overrides = Dict{String,Any}()
-    # Add `@stdlib` to the LOAD_PATH so Pkg can be discovered
-    load_path_sep = Sys.iswindows() ? ";" : ":"
-    load_path_entries = [project_arg, "@stdlib"]
+    # Drop any inherited JULIA_LOAD_PATH (e.g. set by the Pkg-app shim to
+    # JuliaC's own env) so the subprocess falls back to the default
+    # ["@", "@v#.#", "@stdlib"] and `using Pkg` resolves via @stdlib.
+    env_overrides = Dict{String,Any}("JULIA_LOAD_PATH" => nothing)
     tmp_prefs_env = nothing
     if is_trim_enabled(recipe)
+        load_path_sep = Sys.iswindows() ? ";" : ":"
         # Create a temporary environment with a LocalPreferences.toml that will be added to JULIA_LOAD_PATH.
         tmp_prefs_env = mktempdir()
         open(joinpath(tmp_prefs_env, "Project.toml"), "w") do io
@@ -121,9 +122,10 @@ function compile_products(recipe::ImageRecipe)
             println(io, "[HostCPUFeatures]")
             println(io, "freeze_cpu_target = true")
         end
-        push!(load_path_entries, tmp_prefs_env)
+        # Leading separator → an empty entry that expands to the default load path,
+        # then append the temp prefs env.
+        env_overrides["JULIA_LOAD_PATH"] = load_path_sep * tmp_prefs_env
     end
-    env_overrides["JULIA_LOAD_PATH"] = join(load_path_entries, load_path_sep)
 
     inst_cmd = addenv(`$(Base.julia_cmd(cpu_target=precompile_cpu_target)) --project=$project_arg -e "using Pkg; Pkg.instantiate(); Pkg.precompile()"`, env_overrides...)
     recipe.verbose && println("Running: $inst_cmd")

--- a/src/compiling.jl
+++ b/src/compiling.jl
@@ -124,7 +124,8 @@ function compile_products(recipe::ImageRecipe)
         env_overrides["JULIA_LOAD_PATH"] = load_path_sep * tmp_prefs_env
     end
 
-    inst_cmd = addenv(`$(Base.julia_cmd(cpu_target=precompile_cpu_target))  -e "using Pkg; Pkg.activate(\"$project_arg\"); Pkg.instantiate(); Pkg.precompile()"`, env_overrides...)    recipe.verbose && println("Running: $inst_cmd")
+    inst_cmd = addenv(`$(Base.julia_cmd(cpu_target=precompile_cpu_target))  -e "using Pkg; Pkg.activate(\"$project_arg\"); Pkg.instantiate(); Pkg.precompile()"`, env_overrides...)
+    recipe.verbose && println("Running: $inst_cmd")
     precompile_time = time_ns()
     if !success(pipeline(inst_cmd; stdout, stderr))
         error("Error encountered during instantiate/precompile of app project.")

--- a/src/compiling.jl
+++ b/src/compiling.jl
@@ -105,10 +105,7 @@ function compile_products(recipe::ImageRecipe)
     project_arg = isdir(project_arg) ? tmp_project : joinpath(tmp_project, basename(project_arg))
 
     env_overrides = Dict{String,Any}()
-    # Pin JULIA_LOAD_PATH to the user's project plus `@stdlib` so that
-    # `using Pkg` resolves via the stdlib (no Pkg dep required in the user's
-    # project, and JuliaC's own env doesn't leak through when JuliaC is
-    # invoked as a Pkg app — see #127).
+    # Add `@stdlib` to the LOAD_PATH so Pkg can be discovered
     load_path_sep = Sys.iswindows() ? ";" : ":"
     load_path_entries = [project_arg, "@stdlib"]
     tmp_prefs_env = nothing

--- a/src/compiling.jl
+++ b/src/compiling.jl
@@ -124,7 +124,7 @@ function compile_products(recipe::ImageRecipe)
         env_overrides["JULIA_LOAD_PATH"] = load_path_sep * tmp_prefs_env
     end
 
-    inst_cmd = addenv(`$(Base.julia_cmd(cpu_target=precompile_cpu_target))  -e "using Pkg; Pkg.activate(only(ARGS)); Pkg.instantiate(); Pkg.precompile()" $project_arg`, env_overrides...)
+    inst_cmd = addenv(`$(Base.julia_cmd(cpu_target=precompile_cpu_target)) --project=$project_arg -e "using Pkg; Pkg.instantiate(); Pkg.precompile()"`, env_overrides...)
     recipe.verbose && println("Running: $inst_cmd")
     precompile_time = time_ns()
     if !success(pipeline(inst_cmd; stdout, stderr))

--- a/src/compiling.jl
+++ b/src/compiling.jl
@@ -124,7 +124,7 @@ function compile_products(recipe::ImageRecipe)
         env_overrides["JULIA_LOAD_PATH"] = load_path_sep * tmp_prefs_env
     end
 
-    inst_cmd = addenv(`$(Base.julia_cmd(cpu_target=precompile_cpu_target))  -e "using Pkg; Pkg.activate(\"$project_arg\"); Pkg.instantiate(); Pkg.precompile()"`, env_overrides...)
+    inst_cmd = addenv(`$(Base.julia_cmd(cpu_target=precompile_cpu_target))  -e "using Pkg; Pkg.activate(only(ARGS)); Pkg.instantiate(); Pkg.precompile()" $project_arg`, env_overrides...)
     recipe.verbose && println("Running: $inst_cmd")
     precompile_time = time_ns()
     if !success(pipeline(inst_cmd; stdout, stderr))

--- a/src/compiling.jl
+++ b/src/compiling.jl
@@ -124,8 +124,7 @@ function compile_products(recipe::ImageRecipe)
         env_overrides["JULIA_LOAD_PATH"] = load_path_sep * tmp_prefs_env
     end
 
-    inst_cmd = addenv(`$(Base.julia_cmd(cpu_target=precompile_cpu_target)) --project=$project_arg -e "using Pkg; Pkg.instantiate(); Pkg.precompile()"`, env_overrides...)
-    recipe.verbose && println("Running: $inst_cmd")
+    inst_cmd = addenv(`$(Base.julia_cmd(cpu_target=precompile_cpu_target))  -e "using Pkg; Pkg.activate(\"$project_arg\"); Pkg.instantiate(); Pkg.precompile()"`, env_overrides...)    recipe.verbose && println("Running: $inst_cmd")
     precompile_time = time_ns()
     if !success(pipeline(inst_cmd; stdout, stderr))
         error("Error encountered during instantiate/precompile of app project.")

--- a/src/compiling.jl
+++ b/src/compiling.jl
@@ -105,9 +105,14 @@ function compile_products(recipe::ImageRecipe)
     project_arg = isdir(project_arg) ? tmp_project : joinpath(tmp_project, basename(project_arg))
 
     env_overrides = Dict{String,Any}()
+    # Pin JULIA_LOAD_PATH to the user's project plus `@stdlib` so that
+    # `using Pkg` resolves via the stdlib (no Pkg dep required in the user's
+    # project, and JuliaC's own env doesn't leak through when JuliaC is
+    # invoked as a Pkg app — see #127).
+    load_path_sep = Sys.iswindows() ? ";" : ":"
+    load_path_entries = [project_arg, "@stdlib"]
     tmp_prefs_env = nothing
     if is_trim_enabled(recipe)
-        load_path_sep = Sys.iswindows() ? ";" : ":"
         # Create a temporary environment with a LocalPreferences.toml that will be added to JULIA_LOAD_PATH.
         tmp_prefs_env = mktempdir()
         open(joinpath(tmp_prefs_env, "Project.toml"), "w") do io
@@ -119,10 +124,9 @@ function compile_products(recipe::ImageRecipe)
             println(io, "[HostCPUFeatures]")
             println(io, "freeze_cpu_target = true")
         end
-        # Append the temp env to JULIA_LOAD_PATH
-
-        env_overrides["JULIA_LOAD_PATH"] = load_path_sep * tmp_prefs_env
+        push!(load_path_entries, tmp_prefs_env)
     end
+    env_overrides["JULIA_LOAD_PATH"] = join(load_path_entries, load_path_sep)
 
     inst_cmd = addenv(`$(Base.julia_cmd(cpu_target=precompile_cpu_target)) --project=$project_arg -e "using Pkg; Pkg.instantiate(); Pkg.precompile()"`, env_overrides...)
     recipe.verbose && println("Running: $inst_cmd")


### PR DESCRIPTION
This way we rely on the stdlib lookup of Pkg (e.g. `julia -e 'using Pkg'` just works), and then activate the project in question.