### PR TITLE
use rstrip to handle linux&windows seperators

### DIFF
--- a/src/scripts/juliac-buildscript.jl
+++ b/src/scripts/juliac-buildscript.jl
@@ -79,10 +79,7 @@ end
 
 let usermod
     if isdir(source_path)
-        patharg = source_path
-        if endswith(patharg, "/")
-            patharg = chop(patharg)
-        end
+        patharg = rstrip(source_path, ['/', '\\'])
         dname = splitdir(patharg)[2]
         pkgname = Symbol(splitext(dname)[1])
         Base.eval(Main, :(using $pkgname))


### PR DESCRIPTION
Before patch, on Windows, the `source_path` ends in '\\' so `pkgname` comes out empty:

```
PS C:\Users\283710C\files\forks\JuliaC.jl> julia --project -e "using JuliaC; JuliaC.main(ARGS)" -- --output-exe app_test_exe --bundle build --trim=safe --experimental .\test\AppProject\
     Project No packages added to or removed from `C:\Users\283710C\AppData\Local\Temp\jl_6jgWPr\Project.toml`
    Manifest No packages added to or removed from `C:\Users\283710C\AppData\Local\Temp\jl_6jgWPr\Manifest.toml`
Precompiling packages finished.
  1 dependency successfully precompiled in 1 seconds
◒ Compiling...ArgumentError: Package  not found in current path.
- Run `import Pkg; Pkg.add("")` to install the  package.
Stacktrace:
  [1] macro expansion
    @ .\loading.jl:2405 [inlined]
  [2] macro expansion
    @ .\lock.jl:376 [inlined]
  [3] __require(into::Module, mod::Symbol)
    @ Base .\loading.jl:2388
  [4] require(into::Module, mod::Symbol)
    @ Base .\loading.jl:2364
  [5] eval(m::Module, e::Any)
    @ Core .\boot.jl:489
  [6] eval
    @ .\Base_compiler.jl:146 [inlined]
  [7] top-level scope
    @ C:\Users\283710C\files\forks\JuliaC.jl\src\scripts\juliac-buildscript.jl:88
  [8] include(mod::Module, _path::String)
    @ Base .\Base.jl:306
  [9] exec_options(opts::Base.JLOptions)
    @ Base .\client.jl:317
 [10] _start()
    @ Base .\client.jl:550
in expression starting at C:\Users\283710C\files\forks\JuliaC.jl\src\scripts\juliac-buildscript.jl:80
✓ Compiling...
ERROR: Failed to compile .\test\AppProject\
Stacktrace:
 [1] error(s::String)
   @ Base .\error.jl:44
 [2] compile_products(recipe::ImageRecipe)
   @ JuliaC C:\Users\283710C\files\forks\JuliaC.jl\src\compiling.jl:167
 [3] _main_cli(args::Vector{String}; io::Base.TTY)
   @ JuliaC C:\Users\283710C\files\forks\JuliaC.jl\src\JuliaC.jl:208
 [4] _main_cli(args::Vector{String})
   @ JuliaC C:\Users\283710C\files\forks\JuliaC.jl\src\JuliaC.jl:199
 [5] main(ARGS::Vector{String})
   @ JuliaC C:\Users\283710C\files\forks\JuliaC.jl\src\JuliaC.jl:214
 [6] top-level scope
   @ none:1
 [7] eval(m::Module, e::Any)
   @ Core .\boot.jl:489
 [8] exec_options(opts::Base.JLOptions)
   @ Base .\client.jl:283
 [9] _start()
   @ Base .\client.jl:550
```

This patch gets the example compiling on Windows.