### PR TITLE
ABI export: export `NTuple{N,T}` as "array"

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "JuliaC"
 uuid = "acedd4c2-ced6-4a15-accc-2607eb759ba2"
-version = "0.3.2"
+version = "0.3.3"
 authors = ["gbaraldi <baraldigabriel@gmail.com>"]
 
 [deps]

--- a/src/abi_export.jl
+++ b/src/abi_export.jl
@@ -12,7 +12,7 @@ function recursively_add_types!(types::Base.IdSet{DataType}, @nospecialize(T::Da
         T = T.parameters[1] # unwrap Ptr{...}
         T in types && return types
     end
-    if T.name.module === Core && T ∉ C_friendly_types
+    if T.name.module === Core && T ∉ C_friendly_types && !(T <: Tuple)
         error("invalid type for juliac: ", T) # exclude internals (they may change)
     end
     push!(types, T)
@@ -126,11 +126,41 @@ function emit_primitive_type!(ctx::TypeEmitter, @nospecialize(dt::DataType); ind
     end
 end
 
+function is_homogeneous_tuple(@nospecialize(dt::DataType))
+    dt <: Tuple || return false
+    n = fieldcount(dt)
+    n > 0 || return false
+    fts = fieldtypes(dt)
+    T = fts[1]
+    for i = 2:n
+        fts[i] === T || return false
+    end
+    return true
+end
+
+function emit_array_info!(ctx::TypeEmitter, @nospecialize(dt::DataType); indent::Int = 0)
+    type_id = ctx.type_ids[dt]
+    element_type_id = ctx.type_ids[fieldtype(dt, 1)]
+    let indented_println(args...) = println(ctx.io, " " ^ indent, args...)
+        indented_println("{")
+        indented_println("  \"id\": ", type_id, ",")
+        indented_println("  \"kind\": \"array\",")
+        indented_println("  \"name\": ", type_name_json(dt), ",")
+        indented_println("  \"element_type_id\": ", element_type_id, ",")
+        indented_println("  \"count\": ", fieldcount(dt), ",")
+        indented_println("  \"size\": ", Core.sizeof(dt), ",")
+        indented_println("  \"alignment\": ", Base.datatype_alignment(dt))
+        print(ctx.io, " " ^ indent, "}")
+    end
+end
+
 function emit_type_info!(ctx::TypeEmitter, @nospecialize(dt::DataType); indent::Int = 0)
     if dt.name === Ptr.body.name
         emit_pointer_info!(ctx, dt; indent)
     elseif Base.isprimitivetype(dt)
         emit_primitive_type!(ctx, dt; indent)
+    elseif is_homogeneous_tuple(dt)
+        emit_array_info!(ctx, dt; indent)
     else
         emit_struct_info!(ctx, dt; indent)
     end

--- a/test/cli.jl
+++ b/test/cli.jl
@@ -113,6 +113,17 @@ end
     # `Ptr{CTree{Float64}}` should refer (recursively) back to the original type id
     Ptr_CTree_Float64 = abi["types"][CVector_CTree_Float64["fields"][2]["type_id"]]
     @test Ptr_CTree_Float64["pointee_type_id"] == CTree_Float64_id
+
+    # Homogeneous NTuple field should be emitted with `"kind": "array"` rather
+    # than expanded to per-element struct fields.
+    @test any(Bool[type["name"] == "CBuf4" for type in abi["types"]])
+    CBuf4 = abi["types"][findfirst(type["name"] == "CBuf4" for type in abi["types"])]
+    @test length(CBuf4["fields"]) == 1
+    tuple_type = abi["types"][CBuf4["fields"][1]["type_id"]]
+    @test tuple_type["kind"] == "array"
+    @test tuple_type["count"] == 4
+    @test abi["types"][tuple_type["element_type_id"]]["name"] == "Float64"
+    @test tuple_type["size"] == 32
 end
 
 @testset "CLI library privatize end-to-end" begin

--- a/test/libsimple.jl
+++ b/test/libsimple.jl
@@ -36,6 +36,14 @@ Base.@ccallable "copyto_and_sum" function badname(fromto::CVectorPair{Float32}):
     return sum(to)
 end
 
+struct CBuf4
+    data::NTuple{4, Float64}
+end
+
+Base.@ccallable "first_elt" function first_elt(buf::Ptr{CBuf4})::Float64
+    return unsafe_load(buf).data[1]
+end
+
 Base.@ccallable function countsame(list::Ptr{MyTwoVec}, n::Int32)::Int32
     list = unsafe_wrap(Array, list, n)
     count = 0


### PR DESCRIPTION
Previously, `NTuple{N,T}` was exported via the generic `struct` pipeline, creating fields named `1`, `2`, ..., `N`. As most programming languages don't support fields with numeric names, this forces mangling by JuliaLibWrapping and tends to produce long JSON files and bindings. A real-world example is that the upcoming JLWInterop package reports errors using

```
struct JLWStatus
    code::Int32
    message::NTuple{256, UInt8}
end
```

and this ends up creating a structure with 256 fields.

This adds a new export type "array" that can be used to export `NTuple{N,T}` (homogeneous tuples only) as a single field named "array". This is more compact and easier to handle in bindings.