### PR TITLE
Fix non-DataType parameters in ABI exporter

### DIFF
--- a/src/abi_export.jl
+++ b/src/abi_export.jl
@@ -18,6 +18,7 @@ function recursively_add_types!(types::Base.IdSet{DataType}, @nospecialize(T::Da
     push!(types, T)
     for list in (T.parameters, fieldtypes(T))
         for S in list
+            S isa DataType || continue   # skip non-type parameters (Int, TypeVar, Vararg, …)
             recursively_add_types!(types, S)
         end
     end

--- a/test/cli.jl
+++ b/test/cli.jl
@@ -124,6 +124,22 @@ end
     @test tuple_type["count"] == 4
     @test abi["types"][tuple_type["element_type_id"]]["name"] == "Float64"
     @test tuple_type["size"] == 32
+
+    # Parametric struct with a non-type (`Int`) parameter: the build itself
+    # is the test — before the guard in `recursively_add_types!` was added,
+    # iterating `T.parameters` of `CArrayN{Float64,3}` hit the `2`/`3` `Int`
+    # and crashed with a `MethodError`. Confirm the type made it out the
+    # other side and has the expected shape.
+    carray3d = abi["types"][findfirst(t["name"] == "CArrayN{Float64, 3}" for t in abi["types"])]
+    @test carray3d["kind"] == "struct"
+    @test length(carray3d["fields"]) == 2
+    dims_type = abi["types"][carray3d["fields"][1]["type_id"]]
+    @test dims_type["kind"] == "array"
+    @test dims_type["count"] == 3
+    @test abi["types"][dims_type["element_type_id"]]["name"] == "Int32"
+    data_type = abi["types"][carray3d["fields"][2]["type_id"]]
+    @test data_type["kind"] == "pointer"
+    @test abi["types"][data_type["pointee_type_id"]]["name"] == "Float64"
 end
 
 @testset "CLI library privatize end-to-end" begin

--- a/test/libsimple.jl
+++ b/test/libsimple.jl
@@ -44,6 +44,23 @@ Base.@ccallable "first_elt" function first_elt(buf::Ptr{CBuf4})::Float64
     return unsafe_load(buf).data[1]
 end
 
+# Parametric struct with an `Int` (non-type) parameter — mirrors JLWInterop's
+# `CArray{T,N}`. Exercises that `recursively_add_types!` does not stumble
+# over `T.parameters` entries that are not `DataType`s.
+struct CArrayN{T, N}
+    dims::NTuple{N, Int32}
+    data::Ptr{T}
+end
+
+Base.@ccallable "carray3d_sum" function carray3d_sum(a::CArrayN{Float64, 3})::Float64
+    n = Int(a.dims[1]) * Int(a.dims[2]) * Int(a.dims[3])
+    s = 0.0
+    for i in 1:n
+        s += unsafe_load(a.data, i)
+    end
+    return s
+end
+
 Base.@ccallable function countsame(list::Ptr{MyTwoVec}, n::Int32)::Int32
     list = unsafe_wrap(Array, list, n)
     count = 0


### PR DESCRIPTION
This is just a few-line change, but it is built on top of #147 so it appears bigger than it is.

The part specific to this PR is the final two commits, the first adding a test that fails on the (post-147) `main`, and the second the fix. Fine to squash when merging, I just kept them separate in case you wanted to verify the failure yourself.