### PR TITLE
Fix relative path `[sources]` handling

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,6 +14,7 @@ Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Preferences = "21216c6a-2e73-6563-6e65-726566657250"
 RelocatableFolders = "05181044-ff0b-4ac5-8273-598c1e38db00"
 StructIO = "53d494c1-5632-5724-8f4c-31dff12d585f"
+TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 
 [compat]
 LazyArtifacts = "1"

--- a/src/JuliaC.jl
+++ b/src/JuliaC.jl
@@ -1,6 +1,7 @@
 module JuliaC
 
 using Pkg
+using TOML
 using PackageCompiler
 using LazyArtifacts
 using RelocatableFolders

--- a/src/compiling.jl
+++ b/src/compiling.jl
@@ -37,6 +37,37 @@ function _start_spinner(message::String; io::IO=stderr)
     return finished, task
 end
 
+function _absolutize_paths!(x, base)
+    if x isa AbstractDict
+        p = get(x, "path", nothing)
+        if p isa AbstractString && !isabspath(p)
+            x["path"] = abspath(joinpath(base, p))
+        end
+        for v in values(x)
+            _absolutize_paths!(v, base)
+        end
+    elseif x isa AbstractVector
+        for v in values(x)
+            _absolutize_paths!(v, base)
+        end
+    end
+end
+
+# Replace `[sources]` with absolute paths, referenced to `basedir`
+function absolutize_paths!(project_dir, basedir)
+    for f in readdir(project_dir)
+        occursin(r"^(Julia)?(Project|Manifest).*\.toml$", f) || continue
+        file = joinpath(project_dir, f)
+        let data = TOML.parsefile(file)
+            _absolutize_paths!(data, basedir)
+            open(file, "w") do io
+                TOML.print(io, data)
+            end
+        end
+    end
+    return nothing
+end
+
 function compile_products(recipe::ImageRecipe)
     # Only strip IR / metadata if not `--trim=no`
     strip_args = String[]
@@ -103,6 +134,9 @@ function compile_products(recipe::ImageRecipe)
         end
     end
     project_arg = isdir(project_arg) ? tmp_project : joinpath(tmp_project, basename(project_arg))
+
+    # Update any `[sources]` to refer to the original `project_dir`
+    absolutize_paths!(tmp_project, project_dir)
 
     # Always clear JULIA_LOAD_PATH to prevent parent environment leakage
     # (e.g. when JuliaC is invoked as a Pkg app, the shim sets JULIA_LOAD_PATH

--- a/test/RelAppProject/Project.toml
+++ b/test/RelAppProject/Project.toml
@@ -1,0 +1,10 @@
+name = "RelAppProject"
+uuid = "706ac13b-b18e-4f00-9ffc-1dbfdac0cb20"
+version = "0.1.0"
+authors = ["Cody Tapscott <topolarity@tapscott.me>"]
+
+[deps]
+RelDepProject = "a2b563b2-bc84-4a27-9386-51c3ceba0d07"
+
+[sources]
+RelDepProject = {path = "../RelDepProject"}

--- a/test/RelAppProject/src/RelAppProject.jl
+++ b/test/RelAppProject/src/RelAppProject.jl
@@ -1,0 +1,5 @@
+module RelAppProject
+
+greet() = print("Hello World!")
+
+end # module RelAppProject

--- a/test/RelAppProject/src/main.jl
+++ b/test/RelAppProject/src/main.jl
@@ -1,0 +1,6 @@
+using RelDepProject
+
+function @main(ARGS)
+    println(Core.stdout, RelDepProject.greet())
+    return 0
+end

--- a/test/RelDepProject/Project.toml
+++ b/test/RelDepProject/Project.toml
@@ -1,0 +1,3 @@
+name = "RelDepProject"
+uuid = "a2b563b2-bc84-4a27-9386-51c3ceba0d07"
+version = "0.1.0"

--- a/test/RelDepProject/src/RelDepProject.jl
+++ b/test/RelDepProject/src/RelDepProject.jl
@@ -1,0 +1,5 @@
+module RelDepProject
+
+greet() = "hello from a relative-path dependency"
+
+end # module RelDepProject

--- a/test/programatic.jl
+++ b/test/programatic.jl
@@ -577,3 +577,33 @@ end
     # Print tree for debugging/inspection
     print_tree_with_sizes(outdir)
 end
+
+@testset "Relative `[sources]` dep path (#153)" begin
+    # Projects with relative path `[sources]` need special handling
+    # by JuliaC's Project.toml logic
+    relapp_proj = abspath(joinpath(@__DIR__, "RelAppProject"))
+    outdir = mktempdir()
+    exeout = joinpath(outdir, "relapp")
+
+    img = JuliaC.ImageRecipe(
+        file = joinpath(relapp_proj, "src", "main.jl"),
+        output_type = "--output-exe",
+        project = relapp_proj,
+        trim_mode = "safe",
+        verbose = true,
+    )
+    JuliaC.compile_products(img)
+    link = JuliaC.LinkRecipe(image_recipe=img, outname=exeout, rpath=JuliaC.RPATH_BUNDLE)
+    JuliaC.link_products(link)
+    bun = JuliaC.BundleRecipe(link_recipe=link, output_dir=outdir)
+    JuliaC.bundle_products(bun)
+
+    output_exe = if Sys.iswindows()
+        joinpath(outdir, "bin", basename(exeout) * ".exe")
+    else
+        joinpath(outdir, "bin", basename(exeout))
+    end
+    @test isfile(output_exe)
+    output = read(`$output_exe`, String)
+    @test occursin("hello from a relative-path dependency", output)
+end


### PR DESCRIPTION
Fairly straightforward fix: Rewrite the `[sources]` in the copied `Project.toml` / `Manifest.toml` to refer to the original project by absolute path. Resolves https://github.com/JuliaLang/JuliaC.jl/issues/153.

Tests and regex are from Claude 🤖  (but reviewed and reasonable)
