### PR TITLE
buildscript: Query `Project.toml` for package name

### DIFF
--- a/src/scripts/juliac-buildscript.jl
+++ b/src/scripts/juliac-buildscript.jl
@@ -77,14 +77,25 @@ function _main(argc::Cint, argv::Ptr{Ptr{Cchar}})::Cint
     exit(Main.main(args))
 end
 
+# Resolve the package name from a project file's `name` entry
+function get_pkgname(source_path)
+    pkgname = nothing
+    for project_name in Base.project_names
+        path = joinpath(source_path, project_name)
+        if isfile(path)
+            name = get(Base.parsed_toml(path), "name", nothing)
+            if name !== nothing
+                return Symbol(name::String)
+            end
+        end
+    end
+    return nothing
+end
+
 let usermod
     if isdir(source_path)
-        patharg = source_path
-        if endswith(patharg, "/")
-            patharg = chop(patharg)
-        end
-        dname = splitdir(patharg)[2]
-        pkgname = Symbol(splitext(dname)[1])
+        pkgname = get_pkgname(source_path)
+        pkgname === nothing && error("Could not determine a package name: no `name` entry in a Project.toml under \"$source_path\"")
         Base.eval(Main, :(using $pkgname))
         Core.@latestworld
         usermod = getglobal(Main, pkgname)

--- a/test/cli.jl
+++ b/test/cli.jl
@@ -332,6 +332,29 @@ end
     end
 end
 
+@testset "Package dir basename differs from package name" begin
+    # Regression: the buildscript must resolve the package name from the project
+    # file's `name`, not the directory basename. They differ whenever a project is
+    # built from a copy in a differently-named directory (e.g. a temp dir), which
+    # previously failed with `Package <dirname> not found in current path`.
+    projdir = joinpath(mktempdir(), "mismatched_dir_name")
+    cp(TEST_PROJ, projdir)
+    outdir = mktempdir()
+    exename = "renamed_app"
+    cliargs = String[
+        "--output-exe", exename,
+        "--trim=safe",
+        projdir,
+        "--bundle", outdir,
+        "--verbose",
+    ]
+    run_juliac_cli(cliargs)
+    actual_exe = Sys.iswindows() ? joinpath(outdir, "bin", exename * ".exe") : joinpath(outdir, "bin", exename)
+    @test isfile(actual_exe)
+    output = read(`$actual_exe`, String)
+    @test occursin("Fast compilation test!", output)
+end
+
 # End-to-end: install JuliaC as a Pkg app, invoke the shim, compile a project.
 # Unix-only: the Pkg app shim is a shell script on Unix, a .cmd on Windows.
 if Sys.isunix()


### PR DESCRIPTION
Packages frequently share a name with the folder that contains them, but we shouldn't rely on that.

Test generated by Claude Opus 4.8 🤖 