### PR TITLE
Don't run `startup.jl` when validating jl_options stub

### DIFF
--- a/src/compiling.jl
+++ b/src/compiling.jl
@@ -332,7 +332,7 @@ function _compile_jl_options_shim(jl_options::Dict{String,String}; verbose::Bool
     # Validate by running julia with the same flags.
     if !isempty(jl_options)
         julia_bin = joinpath(Sys.BINDIR, "julia")
-        validate_cmd = `$julia_bin`
+        validate_cmd = `$julia_bin --startup-file=no`
         for (key, value) in jl_options
             validate_cmd = `$validate_cmd --$(key)=$(value)`
         end


### PR DESCRIPTION
Currently compiling runs the user `startup.jl` script when validation the `jl_options` stub. This leads to crashes as there is no guarantee that the user `startup.jl` script is actually runnable from the JuliaC environment.