### PR TITLE
test: add regression test for image-object write barriers under --trim

### DIFF
--- a/test/GCImageWBProject/Project.toml
+++ b/test/GCImageWBProject/Project.toml
@@ -1,0 +1,3 @@
+name = "GCImageWBProject"
+uuid = "9c1d7e42-3f5a-4b8c-9d21-6e0b54c7a1f3"
+version = "0.1.0"

--- a/test/GCImageWBProject/src/GCImageWBProject.jl
+++ b/test/GCImageWBProject/src/GCImageWBProject.jl
@@ -1,0 +1,91 @@
+# Regression test for write barriers on image-resident objects in trimmed
+# executables (JuliaLang/julia#61474).
+#
+# TABLE below is a let-bound local captured by global methods -- the same shape
+# as FileWatching's `let FDWatchers = Vector{Any}()`, re-created here so the
+# test does not depend on FileWatching internals. The capture is serialized
+# into the compiled image and, in a trimmed executable, is unreachable from the
+# GC root set:
+#   - there is no module binding for it (and `--trim` strips binding tables
+#     anyway), so it is not reachable through any module;
+#   - the capturing methods are `@noinline`, so they are compiled as standalone
+#     specializations and their method `roots` array (which holds the capture)
+#     suppresses global rooting of the value during native code emission
+#     (`aot_optimize_roots`), and `--trim`/`--strip-ir` then strips method
+#     roots -- leaving TABLE referenced only by native-code gvar slots, which
+#     are not GC roots.
+#
+# Image objects must therefore either be loaded pre-marked
+# (`GC_OLD_MARKED | GC_IN_IMAGE`, the post-julia#61474 behavior) so their
+# write barrier is armed from birth and mutations enroll them in the
+# persistent image remset, or be reachable from the GC roots so the barrier
+# arms on first mark. If a regression resurrects unmarked-and-unreachable
+# image objects (as on Julia 1.12.x and 1.13.0-rc1), the old->young edges
+# created by `push!` below -- a freshly allocated backing Memory and young
+# elements stored into the image-resident Vector -- are recorded in no
+# remset: the GC sweeps the still-referenced memory, the churn recycles it,
+# and the reads crash (UndefRefError or segfault) or return corrupted data
+# instead of printing "survived".
+module GCImageWBProject
+
+let TABLE = Vector{Any}()
+    global @noinline function remember!(@nospecialize(x))
+        push!(TABLE, x)
+        return nothing        # TABLE holds the sole reference
+    end
+    global @noinline table_length() = length(TABLE)
+    global @noinline read_table(i::Int) = TABLE[i]
+end
+
+# Keep the mutating and reading code in their own (non-inlined) frames: if it
+# inlines into main(), stale GC-frame slots of main can keep the young backing
+# Memory reachable across the GC.gc() calls below and mask the bug.
+@noinline function fill_batch!()
+    for i in 1:100
+        remember!(Base.RefValue{Int}(i))
+    end
+    return nothing
+end
+
+@noinline function check_sum()
+    s = 0
+    for i in 1:table_length()
+        r = read_table(i)
+        s += (r::Base.RefValue{Int})[]
+    end
+    return s
+end
+
+# allocation churn in the same size classes as TABLE's backing Memory and
+# elements, so swept (but still referenced) chunks get recycled and overwritten
+@noinline function churn()
+    x = Vector{Any}()
+    for i in 1:20000
+        push!(x, Base.RefValue{Int}(0))
+    end
+    return length(x)
+end
+
+function (@main)(args::Vector{String})::Cint
+    for it in 1:20
+        fill_batch!()
+        GC.gc(it % 3 == 0)   # mix of minor and full collections
+        churn()
+        GC.gc(false)
+        churn()
+        s = check_sum()
+        if s != it * 5050    # each iteration appends Ref.(1:100)
+            print(Core.stderr, "corruption at iteration ")
+            print(Core.stderr, it)
+            print(Core.stderr, ": got sum ")
+            print(Core.stderr, s)
+            print(Core.stderr, ", expected ")
+            println(Core.stderr, it * 5050)
+            return 1
+        end
+    end
+    println(Core.stdout, "survived")
+    return 0
+end
+
+end # module

--- a/test/trimming.jl
+++ b/test/trimming.jl
@@ -1,6 +1,7 @@
 # Trimming tests ported from Base Julia test/trimming/
 
 const TRIM_PROJ = abspath(joinpath(@__DIR__, "TrimmabilityProject"))
+const GC_IMAGE_WB_PROJ = abspath(joinpath(@__DIR__, "GCImageWBProject"))
 
 @testset "Trimming: executable size check" begin
     # Uses the existing TEST_SRC (test.jl) hello world
@@ -109,4 +110,36 @@ end
     @test length(output) == 2
     @test output[1] == "Sum of copied values: 6.000000"
     @test output[2] == "Count of same vectors: 1"
+end
+
+# Regression test for write barriers on image-resident objects
+# (JuliaLang/julia#61474): under `--trim`, an image-resident object can end up
+# unreachable from the GC root set (the fixture re-creates the FileWatching
+# FDWatchers shape: a let-bound local captured by compiled global methods);
+# image objects must load pre-marked so their write barrier is armed from
+# birth, or runtime mutations of them lose their old->young edges and the GC
+# frees live memory. See the fixture for details.
+@testset "Trimming: image-object write barrier regression (GCImageWBProject)" begin
+    outdir = mktempdir()
+    exeout = joinpath(outdir, "gc_image_wb")
+
+    img = JuliaC.ImageRecipe(
+        file = GC_IMAGE_WB_PROJ,
+        output_type = "--output-exe",
+        trim_mode = "safe",
+        quiet = true,
+    )
+    JuliaC.compile_products(img)
+    link = JuliaC.LinkRecipe(image_recipe=img, outname=exeout)
+    JuliaC.link_products(link)
+    bun = JuliaC.BundleRecipe(link_recipe=link, output_dir=outdir)
+    JuliaC.bundle_products(bun)
+
+    actual_exe = Sys.iswindows() ? joinpath(outdir, "bin", basename(exeout) * ".exe") : joinpath(outdir, "bin", basename(exeout))
+    @test isfile(actual_exe)
+
+    # On builds where image objects load unmarked and root-unreachable
+    # (pre-julia#61474), this crashes deterministically on the first
+    # iteration instead of printing "survived".
+    @test readchomp(`$actual_exe`) == "survived"
 end


### PR DESCRIPTION
In a trimmed executable, an image-resident object can be live yet unreachable from the GC root set. The fixture re-creates the shape of FileWatching's `let FDWatchers = Vector{Any}()` -- a let-bound local captured by compiled global methods -- so the test does not depend on FileWatching internals and cannot be silently detuned by stdlib refactors. There is no module binding for the capture (`--trim` strips binding tables anyway); because the capturing methods are compiled as standalone specializations, their method `roots` array (which holds the capture) suppresses global rooting of it during native code emission (`aot_optimize_roots`), and `--trim`/`--strip-ir` then strips method roots -- leaving the object referenced only by native-code gvar slots, which are not GC roots.

Correctness then requires the invariant guarded here: image objects must either be loaded pre-marked (`GC_OLD_MARKED | GC_IN_IMAGE`, the JuliaLang/julia#61474 behavior) so their write barrier is armed from birth and mutations register them in the persistent image remset, or be reachable from the GC roots so the barrier arms on first mark.

Julia 1.12.x and 1.13.0-rc1 satisfied neither: image objects loaded unmarked (`GC_OLD | GC_IN_IMAGE`) with the write barrier gated on `GC_OLD_MARKED`, so the old->young edge created when `push!` stored a freshly allocated backing Memory into the image-resident Vector was recorded in no remset; the next GC swept the still-referenced Memory and its recycled page corrupted the heap - a deterministic use-after-free hit in production by trimmed binaries using Downloads/FileWatching (diagnosed via rr on a juliac binary).

The fixture mutates the captured Vector against minor/full collections and allocation churn in the matching size classes, then reads the contents back. Built with 1.13.0-rc1 or 1.12.6 it crashes deterministically on the first iteration (UndefRefError or segfault reading the recycled backing Memory); with the fix present (1.13.0-rc2+, master) it survives all 20 iterations and prints "survived".
