### PR TITLE
Ask Julia which runtime libraries to bundle

### DIFF
--- a/src/JuliaC.jl
+++ b/src/JuliaC.jl
@@ -4,6 +4,7 @@ using Pkg
 using TOML
 using PackageCompiler
 using LazyArtifacts
+using Libdl
 using RelocatableFolders
 using Preferences
 
@@ -67,6 +68,7 @@ end
 
 include("compiling.jl")
 include("linking.jl")
+include("runtime_libraries.jl")
 include("bundling.jl")
 include("patchversion.jl")
 include("privatize_common.jl")

--- a/src/bundling.jl
+++ b/src/bundling.jl
@@ -23,7 +23,7 @@ function bundle_products(recipe::BundleRecipe)
     ctx2 = PackageCompiler.create_pkg_context(image_recipe.instantiated_project)
     stdlibs = unique(vcat(PackageCompiler.gather_stdlibs_project(ctx2),
                           intersect(PackageCompiler._STDLIBS, map(x->x.name, Base._sysimage_modules))))
-    libs_info = PackageCompiler.bundle_julia_libraries(recipe.output_dir, stdlibs; quiet)
+    libs_info = bundle_libraries(recipe, stdlibs)
     artifacts_info = PackageCompiler.bundle_artifacts(ctx2, recipe.output_dir;
             include_lazy_artifacts=recipe.bundle_lazy_artifacts, quiet) # Lazy artifacts
     PackageCompiler.bundle_cert(recipe.output_dir) # SSL certificates

--- a/src/runtime_libraries.jl
+++ b/src/runtime_libraries.jl
@@ -1,0 +1,104 @@
+# Which shared libraries a bundle needs is declared by Julia itself, via
+# `Base.Linking.runtime_libraries` (Julia 1.14 and later), so that the list keeps matching
+# the runtime as its dependencies change. Julia versions that do not declare it are served by
+# `runtime_libraries_compat.jl`, which is where everything that duplicates Julia's own
+# functionality lives.
+
+const _JULIA_DECLARES_RUNTIME_LIBRARIES = isdefined(Base.Linking, :runtime_libraries)
+
+@static if !_JULIA_DECLARES_RUNTIME_LIBRARIES
+    include("runtime_libraries_compat.jl")
+end
+
+# The directory holding the shared libraries of the running Julia installation (`bin` on
+# Windows, `lib` elsewhere), and the one holding its private libraries.
+julia_shlibdir() = JuliaConfig.libDir()
+julia_private_shlibdir() = JuliaConfig.private_libDir()
+
+"""
+    runtime_libraries(; codegen::Bool=true) -> Vector{String}
+
+Absolute paths of the shared library files of the running Julia installation that a program
+embedding the Julia runtime needs at run time, including the version symlinks that go with
+them.
+
+Pass `codegen=false` for a program that never generates native code at run time (a `--trim`
+build), which drops `libjulia-codegen` and LLVM.
+"""
+function runtime_libraries(; codegen::Bool=true)
+    @static if _JULIA_DECLARES_RUNTIME_LIBRARIES
+        components = codegen ? Base.Linking.DEFAULT_COMPONENTS :
+                               filter(!=(:codegen), Base.Linking.DEFAULT_COMPONENTS)
+        return Base.Linking.runtime_libraries(; optional_components = components)
+    else
+        return library_files(runtime_library_names_compat(; codegen))
+    end
+end
+
+"""
+    stdlib_libraries(stdlib) -> Vector{String}
+
+Absolute paths of the shared library files that the standard library `stdlib` provides, e.g.
+`libopenblas` for `OpenBLAS_jll`. These live in the Julia installation, unlike the libraries
+of ordinary JLL packages, which are bundled as artifacts.
+"""
+stdlib_libraries(stdlib::AbstractString) =
+    library_files(get(Vector{String}, PackageCompiler.jll_mapping, stdlib))
+
+# Resolve library names to the files the running Julia installation ships under them.
+@static if _JULIA_DECLARES_RUNTIME_LIBRARIES
+    const library_files = Base.Linking.library_files
+else
+    const library_files = library_files_compat
+end
+
+"""
+    bundle_libraries(recipe::BundleRecipe, stdlibs) -> PackageCompiler.BundledLibraries
+
+Copy the Julia runtime libraries, and the libraries of `stdlibs`, into the bundle.
+
+Each library keeps the location it has relative to the Julia installation's library
+directory, so that the dependency paths embedded in `libjulia` keep resolving.
+"""
+function bundle_libraries(recipe::BundleRecipe, stdlibs)
+    # the `julia` subdirectory is part of the bundle layout even when this Julia keeps its
+    # private libraries in the library directory itself, as a build from source does
+    Sys.isunix() && mkpath(joinpath(recipe.output_dir::String, recipe.libdir, "julia"))
+    # a trimmed program cannot generate code at run time, so it needs neither LLVM nor
+    # `libjulia-codegen`
+    codegen = !is_trim_enabled(recipe.link_recipe.image_recipe)
+    base_dests = _install_libraries(recipe, runtime_libraries(; codegen))
+    stdlib_dests = Pair{String, Vector{String}}[]
+    for stdlib in stdlibs
+        dests = _install_libraries(recipe, stdlib_libraries(stdlib))
+        isempty(dests) || push!(stdlib_dests, stdlib => dests)
+    end
+    return PackageCompiler.BundledLibraries(base_dests, stdlib_dests)
+end
+
+_install_libraries(recipe::BundleRecipe, libs::Vector{String}) =
+    unique!(String[_install_library(recipe, lib) for lib in libs])
+
+# Install a library file into the bundle, preserving symlinks, and return its destination.
+function _install_library(recipe::BundleRecipe, src::String)
+    dest = _bundle_destination(recipe, src)
+    (isfile(dest) || islink(dest)) && return dest
+    mkpath(dirname(dest))
+    if islink(src)
+        target = readlink(src)
+        if basename(target) == target # a plain link to a sibling file, e.g. `libjulia.so.1`
+            symlink(target, dest)
+            return dest
+        end
+    end
+    cp(src, dest; force=true, follow_symlinks=true)
+    return dest
+end
+
+function _bundle_destination(recipe::BundleRecipe, lib::String)
+    rel = relpath(dirname(lib), julia_shlibdir())
+    # a private library outside the library directory (an unusual layout) goes into the
+    # `julia` subdirectory, where the loader looks for it
+    startswith(rel, "..") && (rel = "julia")
+    return normpath(joinpath(recipe.output_dir::String, recipe.libdir, rel, basename(lib)))
+end

--- a/src/runtime_libraries_compat.jl
+++ b/src/runtime_libraries_compat.jl
@@ -1,0 +1,82 @@
+# Resolving libraries in a Julia installation on versions that do not do it themselves, i.e.
+# before `Base.Linking.runtime_libraries` and `Base.Linking.library_files` (Julia 1.14). This
+# file is included only on those versions; everything in it disappears once JuliaC requires
+# Julia 1.14.
+
+# Which libraries the runtime depends on has to come from somewhere, and before Julia
+# declared it the only list around was PackageCompiler's, which is hardcoded per operating
+# system. It has drifted from the runtime, so patch up what we know is missing.
+function runtime_library_names_compat(; codegen::Bool)
+    os = Sys.isapple() ? "mac" : Sys.iswindows() ? "windows" : "linux"
+    names = copy(PackageCompiler.required_libraries[os])
+    # PackageCompiler's list covers the private libraries only
+    push!(names, Base.isdebugbuild() ? "libjulia-debug" : "libjulia")
+    # ... and it does not mention libzstd, which `libjulia-internal` has needed since 1.13;
+    # it ends up in bundles only because `libz` is a prefix of it
+    push!(names, "libzstd")
+    # ... nor the name libLLVM_jll dlopens, which is a symlink beside the library itself
+    codegen && push!(names, Base.libllvm_name)
+    if Base.isdebugbuild()
+        replace!(names, "libjulia-internal" => "libjulia-internal-debug",
+                        "libjulia-codegen" => "libjulia-codegen-debug")
+    end
+    if !codegen
+        filter!(name -> !startswith(name, "libLLVM") && !startswith(name, "libjulia-codegen"), names)
+    end
+    return names
+end
+
+"""
+    library_files_compat(names) -> Vector{String}
+
+The absolute paths of the shared library files that the running Julia installation ships
+under any of `names`, including the version symlinks that go with them.
+
+This is `Base.Linking.library_files` for Julia versions that do not have it.
+"""
+function library_files_compat(names)
+    dirs = Pair{String,Vector{String}}[]
+    for dir in unique!(String[julia_private_shlibdir(), julia_shlibdir()])
+        isdir(dir) && push!(dirs, dir => readdir(dir; sort=true))
+    end
+    paths = String[]
+    for name in names
+        for (dir, files) in dirs
+            found = false
+            for file in files
+                _is_library_file_compat(name, file) || continue
+                push!(paths, joinpath(dir, file))
+                found = true
+            end
+            # a library is not shipped in more than one of these directories
+            found && break
+        end
+    end
+    # several names can refer to the same file, e.g. `libopenblas` and `libopenblas64_`
+    return unique!(paths)
+end
+library_files_compat(name::AbstractString) = library_files_compat((name,))
+
+# `Base.BinaryPlatforms.parse_dl_name_version` exists here, but before Julia 1.14 it rejects
+# a soversion carrying a tag, which is how Julia spells its own LLVM (`libLLVM.so.20.1jl`),
+# so fall back to asking it about the name with such a tag removed.
+function _is_library_file_compat(name::AbstractString, file::AbstractString)
+    for candidate in (file, _strip_soversion_tag(file))
+        parsed = try
+            first(Base.BinaryPlatforms.parse_dl_name_version(candidate))
+        catch ex
+            ex isa ArgumentError || rethrow()
+            continue # not the name of a shared library file
+        end
+        parsed == name && return true
+        # a library may carry its soversion before the extension even on a platform where it
+        # normally follows it, as OpenBLAS does in `libopenblas64_.0.3.33.so`
+        Sys.isapple() && continue
+        first(Base.BinaryPlatforms.parse_dl_name_version(parsed * ".dylib", "macos")) == name && return true
+    end
+    return false
+end
+
+# `libLLVM.so.20.1jl` -> `libLLVM.so.20.1`
+_strip_soversion_tag(file::AbstractString) =
+    replace(file, r"(?<=\d)[A-Za-z][\w\-]*$" => "")

--- a/test/cli.jl
+++ b/test/cli.jl
@@ -25,6 +25,41 @@ end
     @test isfile(actual_exe)
     output = read(`$actual_exe`, String)
     @test occursin("Fast compilation test!", output)
+
+    # the bundle holds every library the runtime needs, and, being trimmed, nothing that is
+    # only needed to generate code at run time
+    bundled = Set{String}()
+    for (root, _, files) in walkdir(outdir), file in files
+        push!(bundled, file)
+    end
+    for lib in JuliaC.runtime_libraries(; codegen=false)
+        @test basename(lib) in bundled
+    end
+    @test !any(f -> startswith(f, "libLLVM") || startswith(f, "libjulia-codegen"), bundled)
+
+    # Every dependency of the bundle that the Julia installation ships has to be in the
+    # bundle as well. A missing one is easy to miss, because the loader then picks up the
+    # system copy on machines that happen to have one, and only fails elsewhere.
+    if Sys.islinux()
+        installed = Set{String}()
+        for dir in (JuliaC.julia_private_shlibdir(), JuliaC.julia_shlibdir())
+            isdir(dir) && union!(installed, readdir(dir))
+        end
+        # `lib*.so` is not always an ELF file: `libgcc_s.so` is a GNU ld script
+        is_elf(path) = open(io -> read(io, 4) == b"\x7fELF", path, "r")
+        binaries = String[actual_exe]
+        for (root, _, files) in walkdir(joinpath(outdir, "lib")), file in files
+            path = joinpath(root, file)
+            occursin(".so", file) && !islink(path) && is_elf(path) && push!(binaries, path)
+        end
+        for binary in binaries
+            needed = readchomp(`$(Patchelf_jll.patchelf()) --print-needed $binary`)
+            for dep in split(needed, '\n'; keepempty=false)
+                dep in installed || continue # provided by the system, not by Julia
+                @test dep in bundled
+            end
+        end
+    end
 end
 
 # Windows expects all binaries to be next to each other, so we can't test this

--- a/test/programatic.jl
+++ b/test/programatic.jl
@@ -51,9 +51,12 @@
             bun = JuliaC.BundleRecipe(link_recipe=link, output_dir=outdir, privatize=true)
             JuliaC.bundle_products(bun)
 
-            julia_dir = joinpath(outdir, "lib", "julia")
-            @test isdir(julia_dir)
-            dylibs = filter(f -> endswith(f, ".dylib") || endswith(f, ".so"), readdir(julia_dir; join=true))
+            # a Julia installation keeps its private libraries in `lib/julia`, a Julia built
+            # from source keeps them in `lib`, and the bundle mirrors that
+            lib_dir = joinpath(outdir, "lib")
+            @test isdir(lib_dir)
+            dylibs = [joinpath(root, f) for (root, _, files) in walkdir(lib_dir) for f in files
+                                        if endswith(f, ".dylib") || endswith(f, ".so")]
             salted = filter(f -> occursin("_libjulia", basename(f)), dylibs)
             @test !isempty(salted)
             for f in salted


### PR DESCRIPTION
Bundling used `PackageCompiler.bundle_julia_libraries`, whose set of runtime libraries is a per-OS list hardcoded in PackageCompiler, together with a special case for the layout of a Julia built from source. Julia 1.14 declares the libraries its runtime depends on (JuliaLang/julia#62593), so ask it instead, and fall back to PackageCompiler's list on older versions.

Each library is now placed where it sits relative to the Julia installation's library directory, which is what the dependency paths embedded in `libjulia` expect and removes the need to know about local builds. For a trimmed program LLVM and `libjulia-codegen` are never copied in the first place, rather than deleted afterwards.

Also fixes the privatization test, which assumed the `lib/julia` layout of an installed Julia and so failed against a Julia built from source.

Tested against a source build of `master` + JuliaLang/julia#62593: the suite passes except `CLI app with math and --cpu-target=generic`, which fails identically on unmodified `main` in that environment ("CPU does not support CX16").

This pull request was written with the assistance of generative AI (Claude Code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)