### PR TITLE
Stub the sigint listener out of trimmed binaries

### DIFF
--- a/src/scripts/juliac-trim-base.jl
+++ b/src/scripts/juliac-trim-base.jl
@@ -8,6 +8,14 @@ end
 
 (f::Base.RedirectStdStream)(io::Core.CoreSTDOUT) = Base._redirect_io_global(io, f.unix_fd)
 
+# Stub the ^C listener task out of trimmed binaries, on Julia versions
+# where SIGINT is delivered through the cancellation system (the listener
+# performs the Julia-side delivery; a trimmed binary has no interactive
+# episode to deliver to).
+if isdefined(Base, :start_sigint_listener)
+    @eval Base start_sigint_listener() = nothing
+end
+
 @eval Base begin
     show(io::IO, ::Colon) = print(io, "Colon()")
     depwarn(msg, funcsym; force::Bool=false) = nothing


### PR DESCRIPTION
Julia's cancellation-based SIGINT delivery (JuliaLang/julia#62655) runs a Julia-side listener task per session. A trimmed binary has no interactive episode to deliver to, and the listener's dynamic dispatch does not trim; stub it out like the profile listener. Guarded by `isdefined` so this is inert on Julia versions without the listener and can merge ahead of the Julia-side change.

This pull request was written with the assistance of generative AI.