### PR TITLE
Use `isa` in GMP type comparison

### DIFF
--- a/src/scripts/juliac-trim-base.jl
+++ b/src/scripts/juliac-trim-base.jl
@@ -189,7 +189,7 @@ end
             ALLOC_OVERFLOW_FUNCTION[] = true
         catch ex
             # ErrorException("ccall: could not find function...")
-            if typeof(ex) != ErrorException
+            if !(ex isa ErrorException)
                 rethrow()
             end
         end


### PR DESCRIPTION
This is more resistant to invalidations and type instability since `isa` is a builtin and cannot have methods added to it. When running the tests locally it fixes the failures from https://github.com/JuliaLang/julia/pull/62658.