### PR TITLE
Implement FreeBSD support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,4 +61,31 @@ jobs:
       - uses: julia-actions/cache@v3
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
-
+  test-freebsd:
+    name: Julia ${{ matrix.version }} - FreeBSD - ${{ matrix.arch }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        version: [ '1' ]
+        arch: [ x86_64 ]
+    steps:
+      - uses: actions/checkout@v7
+      - uses: vmactions/freebsd-vm@v1
+        with:
+          copyback: false
+          arch: ${{ matrix.arch }}
+          prepare: |
+            pkg update -q
+            pkg install -q -y curl
+            mkdir -p /tmp/juliaup
+            curl -fsSL https://install.julialang.org | sh -s -- \
+                --path=/tmp/juliaup \
+                --default-channel=${{ matrix.version }} \
+                --yes \
+                --add-to-path=no \
+                --background-selfupdate=0 \
+                --startup-selfupdate=0
+            ln -s /tmp/juliaup/bin/julia /usr/local/bin/julia
+          run: |
+            julia --project=. -e 'using Pkg; Pkg.instantiate(); Pkg.test()'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,6 @@ jobs:
           prepare: |
             pkg update -q
             pkg install -q -y curl
-            mkdir -p /tmp/juliaup
             curl -fsSL https://install.julialang.org | sh -s -- \
                 --path=/tmp/juliaup \
                 --default-channel=${{ matrix.version }} \

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 *Manifest*.toml
 .vscode
+*.o

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ If you pass `--compile-ccallable` (or set `ImageRecipe.add_ccallables = true`), 
 
 ### Platform notes
 
-- macOS/Linux: requires `clang` or `gcc` available on PATH
+- macOS/Linux/BSD: requires `clang` or `gcc` available on PATH
 - Windows: looks for a MinGW compiler via `LazyArtifacts` or `JULIA_CC`
 - You can override the compiler with `ENV["JULIA_CC"]` (e.g. `clang`/`gcc` path)
 

--- a/src/JuliaC.jl
+++ b/src/JuliaC.jl
@@ -27,7 +27,7 @@ Base.@kwdef mutable struct ImageRecipe
     # compile-time configuration
     verbose::Bool = false
     quiet::Bool = false
-    use_loaded_libs::Bool = false
+    use_loaded_libs::Bool = Sys.isfreebsd()
     # C shim sources to compile and link into the final artifact
     c_sources::Vector{String} = String[]
     cflags::Vector{String} = String[]

--- a/src/bundling.jl
+++ b/src/bundling.jl
@@ -119,16 +119,3 @@ function remove_unnecessary_libraries(recipe::BundleRecipe)
         end
     end
 end
-
-function privatize_libjulia!(recipe::BundleRecipe)
-    if Sys.isapple()
-        privatize_libjulia_macos!(recipe)
-    elseif Sys.islinux()
-        privatize_libjulia_linux!(recipe)
-    else
-        @warn "Privatization not implemented for this OS"
-    end
-end
-
-
-

--- a/src/julia-config.jl
+++ b/src/julia-config.jl
@@ -117,7 +117,7 @@ function cflags(; framework::Bool=false)
     if Sys.isunix()
         print(flags, " -fPIC")
     end
-    if Sys.isapple()
+    if Sys.isbsd()
         print(flags, " -Wno-nullability-completeness")
     end
     return String(take!(flags))

--- a/src/linking.jl
+++ b/src/linking.jl
@@ -23,7 +23,7 @@ function get_rpath(recipe::LinkRecipe)
 
     if Sys.isapple()
         base_token = "-Wl,-rpath,'@loader_path/"
-    elseif Sys.islinux()
+    elseif Sys.isunix()
         base_token = "-Wl,-rpath,'\$ORIGIN/"
     else
         @warn "get_rpath not implemented for this platform"
@@ -35,7 +35,11 @@ function get_rpath(recipe::LinkRecipe)
     base_path = rpath
     flag1 = base_token * base_path * "'"
     flag2 = base_token * priv_path * "'"
-    return string(flag1, " ", flag2)
+    out = string(flag1, " ", flag2)
+    if Sys.isunix() && !Sys.isapple()
+        out *= " -Wl,-z,origin"
+    end
+    return out
 end
 
 function get_compiler_cmd(; cplusplus::Bool=false)
@@ -53,8 +57,13 @@ function get_compiler_cmd(; cplusplus::Bool=false)
                             cplusplus ? "g++.exe" : "gcc.exe")
             compiler_cmd = `$path`
         else
-            compilers_cpp = ("g++", "clang++")
-            compilers_c = ("gcc", "clang")
+            if Sys.isbsd()  # prefer clang on BSDs (including macOS, but there gcc is clang)
+                compilers_cpp = ("clang++", "g++")
+                compilers_c = ("clang", "gcc")
+            else
+                compilers_cpp = ("g++", "clang++")
+                compilers_c = ("gcc", "clang")
+            end
             found_compiler = false
             if cplusplus
                 for compiler in compilers_cpp
@@ -148,7 +157,7 @@ function link_products(recipe::LinkRecipe)
             cmd2 = `$cmd2 -Wl,--out-implib=$(import_lib_path)`
         elseif Sys.isapple()
             cmd2 = `$cmd2 -Wl,-install_name,@rpath/$(lib_name)`
-        elseif Sys.islinux()
+        else
             # Link libm if the compiled code references math symbols, e.g. with --cpu-target=generic
             cmd2 = `$cmd2 -Wl,-soname,$(lib_name) -Wl,--as-needed -lm`
         end

--- a/src/privatize_common.jl
+++ b/src/privatize_common.jl
@@ -1,5 +1,5 @@
 """
-Common privatization logic shared between macOS and Linux.
+Common privatization logic shared between platforms.
 """
 
 using Base: BinaryPlatforms
@@ -9,6 +9,13 @@ using ObjectFile
 abstract type PrivatizePlatform end
 struct MacOSPlatform <: PrivatizePlatform end
 struct LinuxPlatform <: PrivatizePlatform end
+struct FreeBSDPlatform <: PrivatizePlatform end
+struct NoPrivatize <: PrivatizePlatform end
+
+const PRIVATIZE_TARGET = Sys.isapple() ? MacOSPlatform() :
+                         Sys.islinux() ? LinuxPlatform() :
+                         Sys.isfreebsd() ? FreeBSDPlatform() :
+                         NoPrivatize()
 
 # Per-platform hooks (implemented in platform-specific files)
 plat_ext(::PrivatizePlatform) = error("Unsupported platform")
@@ -16,6 +23,13 @@ plat_dep_prefix(::PrivatizePlatform) = error("Unsupported platform")
 plat_set_library_id!(::PrivatizePlatform, libpath::String, new_id::String) = nothing
 plat_install_name_change!(::PrivatizePlatform, binpath::String, old::String, new::String) = error("Unsupported platform change")
 plat_get_deps(::PrivatizePlatform, bin::String) = String[]
+
+privatize_libjulia!(recipe::BundleRecipe) = privatize_libjulia!(recipe, PRIVATIZE_TARGET)
+
+function privatize_libjulia!(::BundleRecipe, ::NoPrivatize)
+    @warn "Privatization not implemented for this OS"
+    return nothing
+end
 
 function privatize_libjulia_common!(recipe::BundleRecipe, platform::PrivatizePlatform)
     bundle_root = recipe.output_dir

--- a/src/privatize_linux.jl
+++ b/src/privatize_linux.jl
@@ -1,11 +1,11 @@
 """
-Linux-specific privatization for libjulia.
+Linux- and FreeBSD-specific privatization for libjulia.
 
 High-level steps:
 1) Copy `libjulia*` and `libjulia-internal*` to salted basenames next to originals.
 2) Set SONAME of each salted library to the salted basename (via patchelf) and DEP_LIBS with ObjectFile.jl
 3) Rewrite DT_NEEDED entries in the built artifact and salted libs to the salted basenames
-   (no `@rpath` on Linux; DT_NEEDED entries are plain basenames).
+   (no `@rpath` on Linux or FreeBSD; DT_NEEDED entries are plain basenames).
 4) Recreate symlinks
 5) Patch symbol versions to avoid interposition.
 6) Remove originals.
@@ -13,11 +13,13 @@ High-level steps:
 
 using Patchelf_jll
 
-function privatize_libjulia_linux!(recipe::BundleRecipe)
-    try
-        salted_paths = privatize_libjulia_common!(recipe, LinuxPlatform())
+const LinuxOrBSD = Union{LinuxPlatform,FreeBSDPlatform}
 
-        # Version-stamp symbol versions to avoid interposition (Linux-specific)
+function privatize_libjulia!(recipe::BundleRecipe, platform::LinuxOrBSD)
+    try
+        salted_paths = privatize_libjulia_common!(recipe, platform)
+
+        # Version-stamp symbol versions to avoid interposition
         if salted_paths !== nothing
             try
                 version_stamp_symbols!(salted_paths, recipe.link_recipe.outname)
@@ -26,21 +28,19 @@ function privatize_libjulia_linux!(recipe::BundleRecipe)
             end
         end
     catch e
-        error("Failed to privatize libjulia on Linux", e)
+        error("Failed to privatize libjulia", e)
     end
 end
 
-# Linux-specific dependency extraction
-function get_dependencies_linux(bin::String)
-    out = read(`$(Patchelf_jll.patchelf()) --print-needed $(bin)`, String)
-    return filter(!isempty, split(out, '\n'))
+function plat_get_deps(::LinuxOrBSD, bin::String)
+    filter!(!isempty, readlines(`$(Patchelf_jll.patchelf()) --print-needed $(bin)`))
 end
 
-function patchelf_replace_needed!(binpath::String, old::String, new::String)
+function plat_install_name_change!(::LinuxOrBSD, binpath::String, old::String, new::String)
     run(`$(Patchelf_jll.patchelf()) --replace-needed $(old) $(new) $(binpath)`)
 end
 
-function patchelf_set_soname!(libpath::String, soname::String)
+function plat_set_library_id!(::LinuxOrBSD, libpath::String, soname::String)
     run(`$(Patchelf_jll.patchelf()) --set-soname $(soname) $(libpath)`)
 end
 
@@ -53,10 +53,5 @@ function version_stamp_symbols!(salted_paths::Dict{String,String}, product::Stri
     PatchVersion.patch_version!(product, old_ver, new_ver)
 end
 
-# Platform hooks for Linux
-plat_ext(::LinuxPlatform) = ".so"
-plat_dep_prefix(::LinuxPlatform) = ""
-plat_set_library_id!(::LinuxPlatform, libpath::String, new_id::String) = patchelf_set_soname!(libpath, basename(new_id))
-plat_install_name_change!(::LinuxPlatform, binpath::String, old::String, new::String) = patchelf_replace_needed!(binpath, old, new)
-plat_get_deps(::LinuxPlatform, bin::String) = get_dependencies_linux(bin)
-
+plat_ext(::LinuxOrBSD) = ".so"
+plat_dep_prefix(::LinuxOrBSD) = ""

--- a/src/privatize_macos.jl
+++ b/src/privatize_macos.jl
@@ -10,16 +10,16 @@ High-level steps:
 5) Remove originals. Codesigning is handled in bundling.
 """
 
-function privatize_libjulia_macos!(recipe::BundleRecipe)
+function privatize_libjulia!(recipe::BundleRecipe, platform::MacOSPlatform)
     try
-        privatize_libjulia_common!(recipe, MacOSPlatform())
+        privatize_libjulia_common!(recipe, platform)
     catch e
-        error("Failed to privatize libjulia on macOS", e)
+        error("Failed to privatize libjulia", e)
     end
 end
 
 # macOS-specific dependency extraction
-function get_dependencies_macos(bin::String)
+function plat_get_deps(::MacOSPlatform, bin::String)
     out = try
         read(`otool -L $(bin)`, String)
     catch
@@ -38,20 +38,16 @@ function get_dependencies_macos(bin::String)
     return deps
 end
 
-function install_name_id!(libpath::String, new_id::String)
+function plat_set_library_id!(::MacOSPlatform, libpath::String, new_id::String)
     run(`install_name_tool -id $(new_id) $(libpath)`)
 end
 
-function install_name_change!(binpath::String, old_id::String, new_id::String)
+function plat_install_name_change!(::MacOSPlatform, binpath::String, old_id::String, new_id::String)
     run(`install_name_tool -change $(old_id) $(new_id) $(binpath)`)
 end
 
-# Platform hooks for macOS
 plat_ext(::MacOSPlatform) = ".dylib"
 plat_dep_prefix(::MacOSPlatform) = "@rpath/"
-plat_set_library_id!(::MacOSPlatform, libpath::String, new_id::String) = install_name_id!(libpath, new_id)
-plat_install_name_change!(::MacOSPlatform, binpath::String, old::String, new::String) = install_name_change!(binpath, old, new)
-plat_get_deps(::MacOSPlatform, bin::String) = get_dependencies_macos(bin)
 
 function _codesign_bundle!(recipe::BundleRecipe)
     quiet = recipe.link_recipe.image_recipe.quiet

--- a/src/scripts/juliac-buildscript.jl
+++ b/src/scripts/juliac-buildscript.jl
@@ -33,7 +33,7 @@ source_path, output_type, add_ccallables, use_loaded_libs, scripts_dir, export_a
     source_path = ""
     output_type = ""
     add_ccallables = false
-    use_loaded_libs = false
+    use_loaded_libs = !Sys.isfreebsd()
     scripts_dir = abspath(dirname(PROGRAM_FILE))
     export_abi = nothing
     it = Iterators.Stateful(ARGS)

--- a/src/scripts/juliac-libdl-overrides.jl
+++ b/src/scripts/juliac-libdl-overrides.jl
@@ -38,6 +38,13 @@ let
                             end
                         end
                     end
+                elseif (nm = first(splitext(libfile))) in ("libjulia", "libjulia-internal")
+                    h = nm == "libjulia" ?
+                        cglobal(:jl_libjulia_handle) :
+                        cglobal(:jl_libjulia_internal_handle)
+                    if h != C_NULL
+                        return h
+                    end
                 end
 
                 # Fall back to normal loader behavior

--- a/test/programatic.jl
+++ b/test/programatic.jl
@@ -51,7 +51,10 @@
             bun = JuliaC.BundleRecipe(link_recipe=link, output_dir=outdir, privatize=true)
             JuliaC.bundle_products(bun)
 
-            julia_dir = joinpath(outdir, "lib", "julia")
+            julia_dir = joinpath(outdir, "lib")
+            if !PackageCompiler.is_local_julia_build()
+                julia_dir = joinpath(julia_dir, "julia")
+            end
             @test isdir(julia_dir)
             dylibs = filter(f -> endswith(f, ".dylib") || endswith(f, ".so"), readdir(julia_dir; join=true))
             salted = filter(f -> occursin("_libjulia", basename(f)), dylibs)
@@ -59,7 +62,7 @@
             for f in salted
                 if Sys.isapple()
                     out = read(`otool -D $(f)`, String)
-                elseif Sys.islinux()
+                else
                     out = read(`$(Patchelf_jll.patchelf()) --print-soname $(f)`, String)
                 end
                 @test occursin("_libjulia", out)
@@ -143,8 +146,8 @@
     end
 
     # https://github.com/JuliaLang/JuliaC.jl/pull/74
-    @testset "Library has SONAME (Linux)" begin
-        if Sys.islinux()
+    @testset "Library has SONAME (Linux/FreeBSD)" begin
+        if Sys.islinux() || Sys.isfreebsd()
             outdir = mktempdir()
             libname = "libhassonametest"
             libout = joinpath(outdir, libname)
@@ -196,8 +199,8 @@
     end
 
     # https://github.com/JuliaLang/JuliaC.jl/pull/69
-    @testset "`ld_flags` passes flags to compiler (Linux + MacOS)" begin
-        if Sys.islinux() || Sys.isapple() 
+    @testset "`ld_flags` passes flags to compiler (Unix)" begin
+        if Sys.isunix()
             outdir = mktempdir()
             libname = "libhasdebugtest"
             libout = joinpath(outdir, libname)
@@ -213,10 +216,10 @@
 
             libfile_name = libname * "." * Base.BinaryPlatforms.platform_dlext()
             libpath = joinpath(outdir, "lib", libfile_name)
-            output = if Sys.islinux()
-                readchomp(`$(Patchelf_jll.patchelf()) --print-rpath $(libpath)`)
+            output = if Sys.isapple()
+                readchomp(`otool -l $(libpath)`)
             else
-                output = readchomp(`otool -l $(libpath)`)
+                readchomp(`$(Patchelf_jll.patchelf()) --print-rpath $(libpath)`)
             end
             @test occursin(rpath, output)
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using Test
 using JuliaC
 using Libdl
 using Patchelf_jll
+using PackageCompiler
 
 const ROOT = abspath(joinpath(@__DIR__, ".."))
 const TEST_PROJ = abspath(joinpath(@__DIR__, "AppProject"))


### PR DESCRIPTION
Things to note:
- Unlike other platforms, `use_loaded_libs` defaults to `true` on FreeBSD. This is because of how `dlopen` interacts with `RUNPATH`: in particular, it seems that `dlopen`ing without an absolute path will use the executable's `RUNPATH` rather than the calling library's (if I understand what's happening correctly, that is).
- We end up calling `dlopen("libjulia-internal", ...)` with no path or suffix, which feels like it's asking for the loaded library, so I've included a branch to handle this among the Libdl overrides. (Also it doesn't work unless I do that.)
- Non-Apple Unix systems will now include `-Wl,-z,origin` among the linker flags.
- `get_compiler_command` now prefers Clang on BSD systems (macOS and FreeBSD) where it's the default compiler. Previously, we were always looking for GCC first, which works on macOS because `gcc` is a lie and is actually Clang.
- I've removed a layer of indirection in the privatization code: rather than having `plat_get_deps`, `plat_install_name_change!`, et al. wrap platform-specific functions, the methods are defined directly with what had been the body of those inner functions. This was part of introducing a `FreeBSDPlatform` and `LinuxOrBSD` alias in privatization.
- Privatization tests now work with local Julia builds by using the PackageCompiler function `is_local_julia_build()` to construct the expected directory structure.
- Most other changes are just modifying branches to be e.g. `Sys.isunix()` instead of `Sys.islinux()`.
- A separate CI step has been added for running tests on FreeBSD using `vmactions/freebsd-vm` with JuliaUp for installation.