### PR TITLE
Drop '-' as a salt character

### DIFF
--- a/src/privatize_common.jl
+++ b/src/privatize_common.jl
@@ -149,6 +149,6 @@ end
 Generate a random salt string for library names.
 """
 function random_salt(len::Int=8)
-    chars = ['a':'z'; 'A':'Z'; '0':'9'; '-'; '_']
+    chars = ['a':'z'; 'A':'Z'; '0':'9'; '_']
     return String(rand(chars, len))
 end

--- a/test/programatic.jl
+++ b/test/programatic.jl
@@ -43,6 +43,9 @@
     end
 
     @testset "Privatization (Unix salted ids)" begin
+        for _ = 1:1000
+            @test !startswith(JuliaC.random_salt(), '-')
+        end
         if Sys.isunix()
             outdir = mktempdir()
             libout = joinpath(outdir, "libprivtest")
@@ -197,7 +200,7 @@
 
     # https://github.com/JuliaLang/JuliaC.jl/pull/69
     @testset "`ld_flags` passes flags to compiler (Linux + MacOS)" begin
-        if Sys.islinux() || Sys.isapple() 
+        if Sys.islinux() || Sys.isapple()
             outdir = mktempdir()
             libname = "libhasdebugtest"
             libout = joinpath(outdir, libname)


### PR DESCRIPTION
Most shell commands don't like filenames starting with '-' as a leading character. This eliminates it altogther as a salting option. Aside from being an easy fix, it makes the names valid C identifiers.

This *huge* PR was made without AI assistance :wink:.