### PR TITLE
Compile test C shims from a temporary directory

### DIFF
--- a/test/programatic.jl
+++ b/test/programatic.jl
@@ -120,10 +120,11 @@
         outdir = mktempdir()
         libname = "libmultiextraobjs"
         libout = joinpath(outdir, libname)
-        c_sources = [
-            abspath(joinpath(@__DIR__, "c", "cshim_extra1.c")),
-            abspath(joinpath(@__DIR__, "c", "cshim_extra2.c")),
-        ]
+        # Compilation deposits the object files alongside their sources, so work
+        # from copies in the temporary directory to keep `test/c` clean.
+        c_sources = map(["cshim_extra1.c", "cshim_extra2.c"]) do name
+            cp(joinpath(@__DIR__, "c", name), joinpath(outdir, name))
+        end
         img = JuliaC.ImageRecipe(
             file = TEST_LIB_SRC,
             output_type = "--output-lib",


### PR DESCRIPTION
`compile_products` writes each C shim's object file next to its source, so compiling directly from `test/c` leaves `.o` files in the repository.

Assisted-by: Claude Opus 5 (claude-opus-5) <noreply@anthropic.com>