### PR TITLE
abi_export: emit Cvoid as a primitive type

### DIFF
--- a/src/abi_export.jl
+++ b/src/abi_export.jl
@@ -113,13 +113,14 @@ function emit_struct_info!(ctx::TypeEmitter, @nospecialize(dt::DataType); indent
     end
 end
 
-function emit_primitive_type!(ctx::TypeEmitter, @nospecialize(dt::DataType); indent::Int = 0)
+function emit_primitive_type!(ctx::TypeEmitter, @nospecialize(dt::DataType); indent::Int = 0,
+                              name_json::String = type_name_json(dt))
     type_id = ctx.type_ids[dt]
     let indented_println(args...) = println(ctx.io, " " ^ indent, args...)
         indented_println("{")
         indented_println("  \"id\": ", type_id, ",")
         indented_println("  \"kind\": \"primitive\",")
-        indented_println("  \"name\": ", type_name_json(dt), ",")
+        indented_println("  \"name\": ", name_json, ",")
         indented_println("  \"signed\": ", (dt <: Signed), ",")
         indented_println("  \"bits\": ", 8 * Base.packedsize(dt), ",") # size for reinterpret / in-register
         indented_println("  \"size\": ", Base.aligned_sizeof(dt), ",") # size with padding / in-memory
@@ -159,6 +160,10 @@ end
 function emit_type_info!(ctx::TypeEmitter, @nospecialize(dt::DataType); indent::Int = 0)
     if dt.name === Ptr.body.name
         emit_pointer_info!(ctx, dt; indent)
+    elseif dt === Cvoid
+        # `Nothing` is a fieldless struct rather than a `primitive type`, but we treat
+        # it the same way we handle primitives (but call it `Cvoid`)
+        emit_primitive_type!(ctx, dt; indent, name_json = escape_string_json("Cvoid"))
     elseif Base.isprimitivetype(dt)
         emit_primitive_type!(ctx, dt; indent)
     elseif is_homogeneous_tuple(dt)

--- a/test/cli.jl
+++ b/test/cli.jl
@@ -139,6 +139,18 @@ end
     data_type = abi["types"][carray3d["fields"][2]["type_id"]]
     @test data_type["kind"] == "pointer"
     @test abi["types"][data_type["pointee_type_id"]]["name"] == "Float64"
+
+    # `Cvoid` is a primitive node named "Cvoid", both as a return type and as the
+    # pointee of `Ptr{Cvoid}`; the fieldless-struct spelling "Nothing" never appears.
+    zero_first = abi["functions"][findfirst(f["symbol"] == "zero_first" for f in abi["functions"])]
+    cvoid_id = zero_first["returns"]["type_id"]
+    cvoid = abi["types"][cvoid_id]
+    @test cvoid["kind"] == "primitive"
+    @test cvoid["name"] == "Cvoid"
+    ptr_cvoid = abi["types"][zero_first["arguments"][1]["type_id"]]
+    @test ptr_cvoid["kind"] == "pointer"
+    @test ptr_cvoid["pointee_type_id"] == cvoid_id
+    @test !any(Bool[type["name"] == "Nothing" for type in abi["types"]])
 end
 
 @testset "CLI library privatize end-to-end" begin

--- a/test/libsimple.jl
+++ b/test/libsimple.jl
@@ -70,6 +70,14 @@ Base.@ccallable function countsame(list::Ptr{MyTwoVec}, n::Int32)::Int32
     return count
 end
 
+Base.@ccallable function zero_first(p::Ptr{Cvoid}, n::Int32)::Cvoid
+    q = Ptr{UInt8}(p)
+    for i in 1:n
+        unsafe_store!(q, 0x00, i)
+    end
+    return nothing
+end
+
 export countsame, copyto_and_sum
 
 # FIXME? varargs


### PR DESCRIPTION
`Nothing` is a fieldless singleton struct, so kind dispatch sent `Cvoid` down the struct path and produced an empty struct node that C consumers cannot represent. It is now emitted as a primitive node named `Cvoid`, which consumers map to `void`, and `Ptr{Cvoid}` pointee ids resolve to that node.

Assisted-by: Claude Code (Opus 5)