### PR TITLE
Reject unrepresentable Nothing types

### DIFF
--- a/src/abi_export.jl
+++ b/src/abi_export.jl
@@ -6,6 +6,10 @@ const C_friendly_types = Base.IdSet{Any}([    # a few of these are redundant to 
 ])
 
 function recursively_add_types!(types::Base.IdSet{DataType}, @nospecialize(T::DataType))
+    if T === Nothing
+        # Returns and pointer pointees are handled without a type node.
+        error("invalid type for juliac: Nothing (Cvoid) is representable in C only as a return type or as the pointee of Ptr{Cvoid}")
+    end
     T in types && return types
     while T.name === Ptr.body.name
         push!(types, T)
@@ -17,11 +21,15 @@ function recursively_add_types!(types::Base.IdSet{DataType}, @nospecialize(T::Da
         error("invalid type for juliac: ", T) # exclude internals (they may change)
     end
     push!(types, T)
-    for list in (T.parameters, fieldtypes(T))
-        for S in list
-            S isa DataType || continue   # skip non-type parameters (Int, TypeVar, Vararg, …)
-            recursively_add_types!(types, S)
-        end
+    for S in T.parameters
+        S isa DataType || continue   # skip non-type parameters (Int, TypeVar, Vararg, …)
+        # Parameters do not need a node unless stored in a field.
+        S === Nothing && continue
+        recursively_add_types!(types, S)
+    end
+    for S in fieldtypes(T)
+        S isa DataType || continue
+        recursively_add_types!(types, S)
     end
     return types
 end

--- a/test/cli.jl
+++ b/test/cli.jl
@@ -51,6 +51,38 @@ if Sys.isunix()
     end
 end
 
+# Test type discovery directly to avoid a separate failed build for each case.
+# Use a module because `abi_export.jl` defines test structs.
+module ABITypeDiscoveryTests
+
+using Test
+
+include(joinpath(@__DIR__, "..", "src", "abi_export.jl"))
+
+struct HasNothingField
+    x::Int
+    y::Nothing
+end
+
+struct PtrWrapper{T}
+    ptr::Ptr{T}
+end
+
+@testset "ABI type discovery and Nothing/Cvoid" begin
+    msg = "representable in C only as a return type"
+    @test_throws msg recursively_add_types!(Base.IdSet{DataType}(), HasNothingField)
+    @test_throws msg recursively_add_types!(Base.IdSet{DataType}(), Tuple{Int, Nothing})
+    @test_throws msg recursively_add_types!(Base.IdSet{DataType}(), Nothing) # bare argument
+
+    types = recursively_add_types!(Base.IdSet{DataType}(), Ptr{Ptr{Cvoid}})
+    @test Ptr{Ptr{Cvoid}} in types && Ptr{Cvoid} in types && Nothing ∉ types
+
+    types = recursively_add_types!(Base.IdSet{DataType}(), PtrWrapper{Cvoid})
+    @test PtrWrapper{Cvoid} in types && Nothing ∉ types
+end
+
+end
+
 @testset "ABI export" begin
     outdir = mktempdir()
     libout = joinpath(outdir, "libsimple")
@@ -163,6 +195,9 @@ end
     ret_ptr_ptr = abi["types"][findfirst(t -> t["id"] == fn_void_ptr_ptr["returns"]["type_id"], abi["types"])::Int]
     @test ret_ptr_ptr["kind"] == "pointer"
     @test ret_ptr_ptr["pointee_type_id"] == ret_ptr["id"]
+
+    # Void is represented by a null return or pointee id, not a type node.
+    @test !any(Bool[type["name"] == "Nothing" for type in abi["types"]])
 end
 
 @testset "CLI library privatize end-to-end" begin


### PR DESCRIPTION
Small follow-up on #122. Reject Nothing in ABI fields, tuple elements, and arguments. Continue to allow Cvoid returns, pointer pointees, and unstored type parameters.

Assisted-by: Claude Fable 5 <noreply@anthropic.com>