### PR TITLE
Export tuple fields instead of throwing on them

### DIFF
--- a/src/abi_export.jl
+++ b/src/abi_export.jl
@@ -65,7 +65,7 @@ function type_name_json(@nospecialize(dt::DataType))
 end
 
 function field_name_json(@nospecialize(dt::DataType), field::Int)
-    name = String(fieldname(dt, field))
+    name = string(fieldname(dt, field))
     return escape_string_json(name)
 end
 

--- a/test/cli.jl
+++ b/test/cli.jl
@@ -91,6 +91,13 @@ end
     @test abi["types"][CVectorPair_Float32["fields"][2]["type_id"]]["name"] == "CVector{Float32}"
     @test CVectorPair_Float32["size"] == sizeof(UInt) * 4
 
+    # A heterogeneous tuple field is numbered: `fieldname` returns an integer
+    # for one, so the name has to be stringified rather than converted.
+    @test any(Bool[type["name"] == "CPairBox" for type in abi["types"]])
+    CPairBox = abi["types"][findfirst(type["name"] == "CPairBox" for type in abi["types"])]
+    inner = abi["types"][CPairBox["fields"][1]["type_id"]]
+    @test [f["name"] for f in inner["fields"]] == ["1", "2"]
+
     # `CTree{Float64}` should have been exported with the correct info
     @test any(Bool[type["name"] == "CTree{Float64}" for type in abi["types"]])
     CTree_Float64_id = findfirst(type["name"] == "CTree{Float64}" for type in abi["types"])

--- a/test/libsimple.jl
+++ b/test/libsimple.jl
@@ -74,6 +74,15 @@ Base.@ccallable return_void(x::Ptr{Cvoid}, y::Ptr{Ptr{Cvoid}})::Cvoid = nothing
 Base.@ccallable return_void_ptr()::Ptr{Cvoid} = Ptr{Cvoid}()
 Base.@ccallable return_void_ptr_ptr()::Ptr{Ptr{Cvoid}} = Ptr{Ptr{Cvoid}}()
 
+# A struct holding a heterogeneous tuple: its fields are numbered, not named.
+struct CPairBox
+    values::Tuple{Int32, Float64}
+end
+
+Base.@ccallable "pair_box_sum" function pair_box_sum(b::CPairBox)::Float64
+    return b.values[1] + b.values[2]
+end
+
 export countsame, copyto_and_sum
 
 # FIXME? varargs


### PR DESCRIPTION
A struct holding a heterogeneous tuple throws during `--export-abi`:

```julia
struct CPairBox
    values::Tuple{Int32, Float64}
end
```

```
MethodError: no method matching String(::Int64)
```

`fieldname` returns an integer for a tuple field, and `String` has no method for one. `string` gives `"1"`, `"2"`, and so on.

A homogeneous tuple never hit this — it goes to `emit_array_info!` instead.

Found while adding a tuple-return carrier to JuliaLibWrapping, where the natural carrier is a struct wrapping a `Tuple`.
