### PR TITLE
Add --static-runtime: link the Julia runtime statically

### DIFF
--- a/src/JuliaC.jl
+++ b/src/JuliaC.jl
@@ -51,6 +51,10 @@ Base.@kwdef mutable struct LinkRecipe
     outname::String = ""
     rpath::String = RPATH_JULIA
     ld_flags::Vector{String} = String[]
+    # Link the Julia runtime statically (libjulia-internal.a) instead of
+    # against libjulia/libjulia-internal shared libraries. Requires a Julia
+    # build that provides lib/libjulia-internal.a. Experimental, exe-only.
+    static_runtime::Bool = false
 end
 
 Base.@kwdef mutable struct BundleRecipe
@@ -86,6 +90,8 @@ function _print_usage(io::IO=stdout)
     println(io, "Options:")
     println(io, "  --output-exe <name>         Output native executable (name only)")
     println(io, "  --output-lib <path>         Output shared library (lib)")
+    println(io, "  --static-runtime            Link the Julia runtime statically (experimental, Linux exe only;")
+    println(io, "                              requires a Julia providing lib/libjulia-internal.a)")
     println(io, "  --output-sysimage <path>    Output shared library (sysimage)")
     println(io, "  --output-o <path>           Output object archive (default for linking)")
     println(io, "  --output-bc <path>          Output LLVM bitcode archive")
@@ -138,6 +144,8 @@ function _parse_cli_args(args::Vector{String})
             image_recipe.trim_mode = "safe"
         elseif arg == "--experimental"
             push!(image_recipe.julia_args, arg)
+        elseif arg == "--static-runtime"
+            link_recipe.static_runtime = true
         elseif arg == "--compile-ccallable"
             image_recipe.add_ccallables = true
         elseif startswith(arg, "--jl-option")

--- a/src/linking.jl
+++ b/src/linking.jl
@@ -87,6 +87,35 @@ function get_compiler_cmd(; cplusplus::Bool=false)
     return compiler_cmd
 end
 
+# Locate the static runtime archive and the external libraries it needs.
+# Returns the linker arguments replacing `-ljulia -ljulia-internal`.
+function _static_runtime_link_args(recipe::LinkRecipe)
+    Sys.islinux() || error("--static-runtime is currently only supported on Linux")
+    if recipe.image_recipe.output_type != "--output-exe"
+        error("--static-runtime currently only supports --output-exe")
+    end
+    libdir = JuliaConfig.libDir()
+    archive = joinpath(libdir, Base.isdebugbuild() ? "libjulia-internal-debug.a" : "libjulia-internal.a")
+    isfile(archive) || error("""
+        --static-runtime requires $(basename(archive)), which this Julia does not provide.
+        Build it from a Julia source tree with `make -C src \$(pwd)/usr/lib/libjulia-internal.a`.
+        Looked in: $libdir""")
+    args = String[]
+    # The image is already linked with --whole-archive by the caller; the
+    # runtime archive needs it too, since Julia code reaches most runtime
+    # symbols through ccall rather than through C references.
+    push!(args, "-Wl,$(Base.Linking.WHOLE_ARCHIVE)", archive, "-Wl,$(Base.Linking.NO_WHOLE_ARCHIVE)")
+    # External libraries the runtime archive depends on. LLVMSupport (used by
+    # the processor/target-selection code) lives in Julia's libdir.
+    append!(args, ["-lunwind", "-lLLVMSupport", "-lLLVMDemangle",
+                   "-lzstd", "-lz", "-lrt", "-ldl", "-lpthread", "-lm", "-latomic", "-lstdc++"])
+    # Image ccalls resolve through the Julia PLT (dlsym on the executable), so
+    # the runtime's symbols must be in the dynamic symbol table; ldflags()
+    # already passes --export-dynamic on Linux. Drop unused jl_* thunks.
+    push!(args, "-Wl,--gc-sections")
+    return args
+end
+
 function link_products(recipe::LinkRecipe)
     link_start = time_ns()
     image_recipe = recipe.image_recipe
@@ -119,8 +148,12 @@ function link_products(recipe::LinkRecipe)
             end
         end
     end
-    rpath_str = Base.shell_split(get_rpath(recipe))
-    julia_libs = Base.shell_split(Base.isdebugbuild() ? "-ljulia-debug -ljulia-internal-debug" : "-ljulia -ljulia-internal")
+    rpath_str = recipe.static_runtime ? String[] : Base.shell_split(get_rpath(recipe))
+    julia_libs = if recipe.static_runtime
+        _static_runtime_link_args(recipe)
+    else
+        Base.shell_split(Base.isdebugbuild() ? "-ljulia-debug -ljulia-internal-debug" : "-ljulia -ljulia-internal")
+    end
     compiler_cmd = get_compiler_cmd()
     allflags = Base.shell_split(JuliaConfig.allflags(; framework=false, rpath=false))
     try


### PR DESCRIPTION
Experimental `--static-runtime` flag: instead of `-ljulia -ljulia-internal`, link `libjulia-internal.a` (whole-archive, like the image) plus its external libraries, producing an executable with the runtime and system image in a single binary — no `libjulia*`/`libuv`/`libutf8proc` at runtime, only system libraries plus `libunwind`/`libzstd`/LLVMSupport's deps.

Requires a Julia providing `lib/libjulia-internal.a` and the runtime-side changes in JuliaLang/julia#62882–#62885 (#62881 already merged) plus JuliaLang/julia#62945. Currently Linux `--output-exe` only; library paths come from the build Julia's libdir (no bundling/relocation yet).

Tested against a source-built Julia with those PRs:
```
juliac --output-exe hello --trim=unsafe --experimental --static-runtime hello.jl
```
→ 16 MB executable, runs Base code/GC, `ldd` shows no Julia libraries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)