### PR TITLE
Use LIEF_Patchelf_jll instead of Patchelf_jll

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,12 +4,12 @@ version = "0.3.9"
 authors = ["gbaraldi <baraldigabriel@gmail.com>"]
 
 [deps]
+LIEF_Patchelf_jll = "d7f80cea-2d23-50ed-9ab7-0409554cddf2"
 LazyArtifacts = "4af54fe1-eca0-43a8-85a7-787d91b784e3"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 Mmap = "a63ad114-7e13-5084-954f-fe012c677804"
 ObjectFile = "d8793406-e978-5875-9003-1fc021f44a92"
 PackageCompiler = "9b87118b-4619-50d2-8e1e-99f35a4d4d9d"
-Patchelf_jll = "f2cf89d6-2bfd-5c44-bd2c-068eea195c0c"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Preferences = "21216c6a-2e73-6563-6e65-726566657250"
 RelocatableFolders = "05181044-ff0b-4ac5-8273-598c1e38db00"
@@ -18,12 +18,12 @@ StructIO = "53d494c1-5632-5724-8f4c-31dff12d585f"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 
 [compat]
+LIEF_Patchelf_jll = "1"
 LazyArtifacts = "1"
 Libdl = "1"
 Mmap = "1"
 ObjectFile = "0.5"
 PackageCompiler = "2.4"
-Patchelf_jll = "0.18"
 Pkg = "1"
 Preferences = "1"
 RelocatableFolders = "1"

--- a/src/privatize_linux.jl
+++ b/src/privatize_linux.jl
@@ -11,7 +11,7 @@ High-level steps:
 6) Remove originals.
 """
 
-using Patchelf_jll
+using LIEF_Patchelf_jll
 
 function privatize_libjulia_linux!(recipe::BundleRecipe, salt::String)
     try
@@ -32,16 +32,16 @@ end
 
 # Linux-specific dependency extraction
 function get_dependencies_linux(bin::String)
-    out = read(`$(Patchelf_jll.patchelf()) --print-needed $(bin)`, String)
+    out = read(`$(LIEF_Patchelf_jll.lief_patchelf()) --print-needed $(bin)`, String)
     return filter(!isempty, split(out, '\n'))
 end
 
 function patchelf_replace_needed!(binpath::String, old::String, new::String)
-    run(`$(Patchelf_jll.patchelf()) --replace-needed $(old) $(new) $(binpath)`)
+    run(`$(LIEF_Patchelf_jll.lief_patchelf()) --replace-needed $(old) $(new) $(binpath)`)
 end
 
 function patchelf_set_soname!(libpath::String, soname::String)
-    run(`$(Patchelf_jll.patchelf()) --set-soname $(soname) $(libpath)`)
+    run(`$(LIEF_Patchelf_jll.lief_patchelf()) --set-soname $(soname) $(libpath)`)
 end
 
 function version_stamp_symbols!(salted_paths::Dict{String,String}, product::String, salt::String)

--- a/test/programatic.jl
+++ b/test/programatic.jl
@@ -63,7 +63,7 @@
                 if Sys.isapple()
                     out = read(`otool -D $(f)`, String)
                 elseif Sys.islinux()
-                    out = read(`$(Patchelf_jll.patchelf()) --print-soname $(f)`, String)
+                    out = read(`$(LIEF_Patchelf_jll.lief_patchelf()) --print-soname $(f)`, String)
                 end
                 @test occursin("_libjulia", out)
             end
@@ -159,7 +159,7 @@
 
             soname = libname * "." * Base.BinaryPlatforms.platform_dlext()
             libpath = joinpath(outdir, "lib", soname)
-            actual_soname = readchomp(`$(Patchelf_jll.patchelf()) --print-soname $(libpath)`)
+            actual_soname = readchomp(`$(LIEF_Patchelf_jll.lief_patchelf()) --print-soname $(libpath)`)
             @test actual_soname == soname
         end
     end
@@ -218,7 +218,7 @@
             libfile_name = libname * "." * Base.BinaryPlatforms.platform_dlext()
             libpath = joinpath(outdir, "lib", libfile_name)
             output = if Sys.islinux()
-                readchomp(`$(Patchelf_jll.patchelf()) --print-rpath $(libpath)`)
+                readchomp(`$(LIEF_Patchelf_jll.lief_patchelf()) --print-rpath $(libpath)`)
             else
                 output = readchomp(`otool -l $(libpath)`)
             end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,7 @@
 using Test
 using JuliaC
 using Libdl
-using Patchelf_jll
+using LIEF_Patchelf_jll
 
 const ROOT = abspath(joinpath(@__DIR__, ".."))
 const TEST_PROJ = abspath(joinpath(@__DIR__, "AppProject"))


### PR DESCRIPTION
Replaces `Patchelf_jll` with `LIEF_Patchelf_jll`, LIEF's reimplementation of
patchelf (`tools/lief-patchelf`, new in LIEF 1.0.0).

### What changed

All five patchelf invocations move over one-for-one:

| call site | flag |
|---|---|
| `get_dependencies_linux` | `--print-needed` |
| `patchelf_replace_needed!` | `--replace-needed` |
| `patchelf_set_soname!` | `--set-soname` |
| tests | `--print-soname`, `--print-rpath` |

I diffed the two binaries side by side on x86_64-linux-gnu (patchelf 0.18 vs
lief-patchelf 1.0.0), against a real `libjulia.so.1.10`:

- `--print-needed`, `--print-soname`, `--print-rpath` — byte-identical output.
- `--set-soname` + `--replace-needed` — identical resulting binaries, verified by
  reading both back with stock patchelf.
- Multi-entry rpaths (`$ORIGIN:$ORIGIN/julia:/opt/foo`) round-trip identically in
  both directions.
- `--replace-needed` for a library that isn't in `DT_NEEDED` — no-op, exit 0 in
  both.

Two intentional behaviour differences, neither reachable from the call sites here:

- `--print-soname` on a file with no `DT_SONAME`: patchelf prints nothing and
  exits 0; lief-patchelf errors and exits 1. Every call site runs on a library
  JuliaC has just *set* the soname on, so the entry always exists — and failing
  loudly is the better default.
- `--print-needed` on a statically linked binary: patchelf errors; lief-patchelf
  succeeds with empty output. Strictly more lenient, and the empty dependency
  list is the correct answer.

### Platform coverage

17 of the 18 Yggdrasil platforms, dropping only `i686-w64-mingw32` (this isn't used there anyway, but a fix is coming for that).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XsxsiLWFcGVPPmjVHrvtYS
