### PR TITLE
reduce: avoid spurious widening for array reduction with `init`

### DIFF
--- a/src/scripts/juliac-trim-base.jl
+++ b/src/scripts/juliac-trim-base.jl
@@ -95,8 +95,15 @@ end
     mapreduce(f::F, op::F2, A::AbstractArrayOrBroadcasted...; kw...) where {F, F2} =
         reduce(op, map(f, A...); kw...)
 
-    _mapreduce_dim(f::F, op::F2, nt, A::AbstractArrayOrBroadcasted, ::Colon) where {F, F2} =
-        mapfoldl_impl(f, op, nt, A)
+    function _mapreduce_dim(f::F, op::F2, nt, A::AbstractArrayOrBroadcasted, ::Colon) where {F, F2}
+        y = iterate(A)
+        y === nothing && return nt
+        v = op(nt, f(y[1]))
+        for x in Iterators.rest(A, y[2])
+            v = op(v, f(x))
+        end
+        return v
+    end
 
     _mapreduce_dim(f::F, op::F2, ::_InitialValue, A::AbstractArrayOrBroadcasted, ::Colon) where {F, F2} =
         _mapreduce(f, op, IndexStyle(A), A)

--- a/test/TrimmabilityProject/Project.toml
+++ b/test/TrimmabilityProject/Project.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 
 [deps]
 HostCPUFeatures = "3e5b6fbb-0976-4d2c-9146-d79de83f2fb0"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
 
 [compat]

--- a/test/TrimmabilityProject/src/TrimmabilityProject.jl
+++ b/test/TrimmabilityProject/src/TrimmabilityProject.jl
@@ -3,6 +3,7 @@ module TrimmabilityProject
 
 using HostCPUFeatures
 using Sockets
+using LinearAlgebra
 
 world::String = "world!"
 const str = OncePerProcess{String}() do
@@ -82,6 +83,15 @@ function _test_cat()
     return _cat1 + _cat2 + _cat3 + _cat4 + _cat5 + _cat6 + _cat7
 end
 
+# reductions with `init` nested in a generator reduction
+function _test_nested_reductions()
+    v = [1.0, 0.0, 2.0]
+    counted = maximum(count(!iszero, v .* i) for i in 1:3)
+    summed = sum(x -> sum(y -> y * x, v; init = 0.0), v; init = 0.0)
+    normed = maximum(norm(v .* i, 1) for i in 1:3)
+    return string("nested reductions: ", counted, " ", summed, " ", normed)
+end
+
 function @main(args::Vector{String})::Cint
     println(Core.stdout, str())
     println(Core.stdout, PROGRAM_FILE)
@@ -101,6 +111,7 @@ function @main(args::Vector{String})::Cint
     # e = reduce(xor, rand(Int, 10))
 
     println(Core.stdout, _test_cat())
+    println(Core.stdout, _test_nested_reductions())
 
     try
         sock = connect("localhost", 4900)

--- a/test/trimming.jl
+++ b/test/trimming.jl
@@ -55,15 +55,17 @@ end
     # 4. arg2
     # 5. The sum_areas result: 4.0 + pi = 7.141592653589793
     # 6. _test_cat() result (a Float64)
+    # 7. nested reductions with `init` inside a generator reduction
     output = readchomp(`$actual_exe arg1 arg2`)
     lines = split(output, '\n')
-    @test length(lines) >= 6
+    @test length(lines) >= 7
     @test lines[1] == "Hello, world!"
     @test lines[2] == actual_exe  # PROGRAM_FILE
     @test lines[3] == "arg1"
     @test lines[4] == "arg2"
     @test parse(Float64, lines[5]) ≈ (4.0 + pi)
     @test parse(Float64, lines[6]) isa Float64
+    @test lines[7] == "nested reductions: 2 9.0 9.0"
 end
 
 @testset "Trimming: libsimple.jl C application test" begin


### PR DESCRIPTION
See JuliaLang/julia#62993 for the upstream changes this copies over.